### PR TITLE
Support ofborg comments inline with other text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 ## Commands
 
-1. To trigger the bot, the comment _must_ start with a case
+The comment parser is line-based, so comments can be interleaved with
+instructions.
+
+1. To trigger the bot, the line _must_ start with a case
    insensitive version of `@GrahamcOfBorg`.
 2. To use multiple commands, insert a bit of whitespace and then your
    new command.
@@ -61,21 +64,25 @@ or even:
 @grahamcofborg build list of attrs @grahamcofborg eval
 ```
 
-This will _not_ work:
+This will also work:
 
 ```
 looks good to me!
 @grahamcofborg build list of attrs
 ```
 
-Also this is bad:
+And this is fine:
 
 ```
 @grahamcofborg build list of attrs
 looks good to me!
 ```
 
-as it'll try to build `list` `of` `attrs` `looks` `good` `to` `me!`.
+This is will build `list`, `of`, `attrs`, `looks`, `good`, `to`, `me!`:
+
+```
+@grahamcofborg build list of attrs looks good to me!
+```
 
 
 # How does OfBorg call nix-build?


### PR DESCRIPTION
The old design of the parser treated all whitespace the same and
mandated that `grahamcofborg` (plus the `@`) be the first token in the
text. This allowed for some ridiculous but command calls:

    grahamcofborg build foo
       bar
          baz

This used to become a build instruction for foo, bar, and baz. After
this change, it is just an instruction for building foo. This allows
for comments for people to be intertwined with comments for the bot:

    grahamcofborg build foo

    Let's see what happens!

Before this would unintentionally become a build instruction for
`foo`, `Let's`, `see`, `what`, `happens!`, and is now only going to
build `foo`.

Additionally, this comment would do nothing:

    Let's see what happens!
    grahamcofborg build foo

Or a more real case where people expected this to work:

    /cc grahamc for ^^
    GrahamcOfBorg eval

This will continue to not produce a build instruction, because
grahamcofborg must be the first word of a line:
    
    foo bar grahamcofbor build foo
    


(Note: I've removed `@`s from all usernames to avoid accidental email)



cc @vcunat