### PR TITLE
factoids: The !unfree link is now less scary

### DIFF
--- a/factoids.toml
+++ b/factoids.toml
@@ -8,4 +8,4 @@
 "!library" = "Don't install libraries through nix-env or systemPackages. See https://nixos.wiki/wiki/FAQ#I_installed_a_library_but_my_compiler_is_not_finding_it._Why.3F for details."
 "!-A" = "You'll usually want to use nix-env -i with -A. It's faster and more precise. See https://nixos.wiki/wiki/FAQ#Why_not_use_nix-env_-i_foo.3F for details."
 "!tofu" = "To get a sha256 hash of a new source, you can use the Trust On First Use model: use probably-wrong hash (for example: 0000000000000000000000000000000000000000000000000000) then replace it with the correct hash Nix expected."
-"!unfree" = "You cannot install your unfree software? See https://nixos.wiki/wiki/FAQ#How_can_I_install_a_proprietary_or_unfree_package.3F"
+"!unfree" = "You cannot install your unfree software? See https://nixos.wiki/wiki/FAQ/unfree"


### PR DESCRIPTION
I've just made the `FAQ/unfree` entry link to the *new* sub-page for the FAQ, which makes it easier to see *what* was linked. The FAQ in the wiki is... a monster we still need to tame!