### PR TITLE
No longer strip x86_64-linux from test jobs

### DIFF
--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -191,20 +191,6 @@ impl<'a, 'b> JobActions<'a, 'b> {
     }
 }
 
-fn strip_x8664linux_arch_suffix(attr: &str) -> &str {
-    if !attr.starts_with("tests.") {
-        return attr;
-    }
-
-    if !attr.ends_with(".x86_64-linux") {
-        return attr;
-    }
-
-    let trim_at = attr.len() - 13;
-
-    return &attr[0..trim_at];
-}
-
 impl notifyworker::SimpleNotifyWorker for BuildWorker {
     type J = buildjob::BuildJob;
 
@@ -250,17 +236,6 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             _ => "./default.nix",
         };
 
-        let attrs = match job.subset {
-            Some(commentparser::Subset::NixOS) => {
-                job.attrs
-                    .clone()
-                    .into_iter()
-                    .map(|attr| strip_x8664linux_arch_suffix(&attr).to_owned())
-                    .collect()
-            }
-            _ => job.attrs.clone(),
-        };
-
         if buildfile == "./nixos/release.nix" && self.system == "x86_64-darwin" {
             actions.nasty_hack_linux_only();
             return;
@@ -287,7 +262,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         let cmd = self.nix.safely_build_attrs_cmd(
             refpath.as_ref(),
             buildfile,
-            attrs,
+            job.attrs.clone(),
         );
 
         actions.log_started();
@@ -447,22 +422,5 @@ mod tests {
         assert_contains_job(&mut actions, "output\":\"4");
         assert_contains_job(&mut actions, "success\":true");
         assert_eq!(actions.next(), Some(worker::Action::Ack));
-    }
-
-    #[test]
-    fn test_strip_x8664linux_arch_suffix() {
-        assert_eq!(strip_x8664linux_arch_suffix(""), "");
-        assert_eq!(
-            strip_x8664linux_arch_suffix("tests.foo.bar"),
-            "tests.foo.bar"
-        );
-        assert_eq!(
-            strip_x8664linux_arch_suffix("foo.bar.x86_64-linux"),
-            "foo.bar.x86_64-linux"
-        );
-        assert_eq!(
-            strip_x8664linux_arch_suffix("tests.foo.bar.x86_64-linux"),
-            "tests.foo.bar"
-        );
     }
 }


### PR DESCRIPTION
Deploy this after https://github.com/NixOS/ofborg/pull/51 is deployed

cc https://github.com/NixOS/ofborg/issues/36