### PR TITLE
config: remove darwin paths

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -44,10 +44,6 @@
         ]
     },
     "tag_paths": {
-        "6.topic: darwin": [
-            "pkgs/top-level/darwin-packages.nix",
-            "pkgs/stdenv/darwin"
-        ],
         "6.topic: emacs": [
             "nixos/modules/services/editors/emacs.nix",
             "nixos/modules/services/editors/emacs.xml",


### PR DESCRIPTION
This is not accurate enough, causing the label to be removed for all
other darwin related changes.