### PR TITLE
fix test with ANSI escape characters

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -261,6 +261,7 @@ mod tests {
 
         let buildlog = lines
             .into_iter()
+            .map(|line| line.replace("\u{1b}[0m", "")) // ANSI reset
             .map(|line| format!("   | {}", line))
             .collect::<Vec<String>>()
             .join("\n");


### PR DESCRIPTION
The nix commands print the error: commands in red, the ANSI reset caused
one of the tests to fail.