### PR TITLE
Clarify autobuild commit parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@
 
 Users who are _trusted_ (see: ./config.public.json) or _known_ (see:
 ./config.known-users.json) will have their PRs automatically trigger
-builds if their commits follow the well-defined format of Nixpkgs.
+builds if their commits follow the well-defined format of Nixpkgs,
+specifically prefixing the commit title with the package attribute.
+This includes package bumps as well as other changes.
 Example messages and the builds:
 
 |Message|Automatic Build|
 |-|-|
 |`vim: 1.0.0 -> 2.0.0`|`vim`|
+|`vagrant: Fix dependencies for version 2.0.2 `|`vagrant`|
 |`python36Packages.requests,python27Packages.requests: 1.0.0 -> 2.0.0`|`python36Packages.requests`, `python27Packages.requests`|
 |`python{2,3}Packages.requests: 1.0.0 -> 2.0.0`|_nothing_|
 


### PR DESCRIPTION
I didn't realize the bot would recognize all commits, not just version bumps, since all the examples use version bumps, and inadvertenly retriggered the bot on https://github.com/NixOS/nixpkgs/pull/36283 without realizing it was already autobuilding.

Thanks again for the bot @grahamc, it's invaluable!