### PR TITLE
Add abbradar to trusted_users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -13,6 +13,7 @@
         ],
         "trusted_users": [
             "7c6f434c",
+            "abbradar",
             "adisbladis",
             "andir",
             "ankhers",


### PR DESCRIPTION
I want to fix several packages on Darwin but don't have a test machine -- having our trusty bot's help would be nice.