### PR TITLE
Record build status - 0.1.3

### DIFF
--- a/nix/ofborg-carnix.nix
+++ b/nix/ofborg-carnix.nix
@@ -45,7 +45,7 @@ let kernel = buildPlatform.parsed.kernel.name;
     ) [] (builtins.attrNames feat);
 in
 rec {
-  ofborg = f: ofborg_0_1_2 { features = ofborg_0_1_2_features { ofborg_0_1_2 = f; }; };
+  ofborg = f: ofborg_0_1_3 { features = ofborg_0_1_3_features { ofborg_0_1_3 = f; }; };
   aho_corasick_0_5_3_ = { dependencies?[], buildDependencies?[], features?[] }: buildRustCrate {
     crateName = "aho-corasick";
     version = "0.5.3";

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofborg"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Graham Christensen <graham@grahamc.com>"]
 include = ["Cargo.toml", "Cargo.lock", "src", "test-srcs", "build.rs"]
 build = "build.rs"

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -189,12 +189,20 @@ impl<'a, 'b> JobActions<'a, 'b> {
 
         let result_exchange = self.result_exchange.clone();
         let result_routing_key = self.result_routing_key.clone();
-
         self.tell(worker::publish_serde_action(
             result_exchange,
             result_routing_key,
             &msg,
         ));
+
+        let log_exchange = self.log_exchange.clone();
+        let log_routing_key = self.log_routing_key.clone();
+        self.tell(worker::publish_serde_action(
+            log_exchange,
+            log_routing_key,
+            &msg,
+        ));
+
         self.tell(worker::Action::Ack);
     }
 
@@ -216,12 +224,20 @@ impl<'a, 'b> JobActions<'a, 'b> {
 
         let result_exchange = self.result_exchange.clone();
         let result_routing_key = self.result_routing_key.clone();
-
         self.tell(worker::publish_serde_action(
             result_exchange,
             result_routing_key,
             &msg,
         ));
+
+        let log_exchange = self.log_exchange.clone();
+        let log_routing_key = self.log_routing_key.clone();
+        self.tell(worker::publish_serde_action(
+            log_exchange,
+            log_routing_key,
+            &msg,
+        ));
+
         self.tell(worker::Action::Ack);
     }
 

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -492,7 +492,8 @@ mod tests {
         assert_contains_job(&mut actions, "output\":\"2");
         assert_contains_job(&mut actions, "output\":\"3");
         assert_contains_job(&mut actions, "output\":\"4");
-        assert_contains_job(&mut actions, "success\":true");
+        assert_contains_job(&mut actions, "success\":true"); // First one to the github poster
+        assert_contains_job(&mut actions, "success\":true"); // This one to the logs
         assert_eq!(actions.next(), Some(worker::Action::Ack));
     }
 
@@ -533,7 +534,8 @@ mod tests {
 
         println!("Total actions: {:?}", dummyreceiver.actions.len());
         let mut actions = dummyreceiver.actions.into_iter();
-        assert_contains_job(&mut actions, "skipped_attrs\":[\"not-real");
+        assert_contains_job(&mut actions, "skipped_attrs\":[\"not-real"); // First one to the github poster
+        assert_contains_job(&mut actions, "skipped_attrs\":[\"not-real"); // This one to the logs
         assert_eq!(actions.next(), Some(worker::Action::Ack));
     }
 }

--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -207,7 +207,9 @@ impl worker::SimpleWorker for LogMessageCollector {
 
                 handle.write_to_line((message.line_number - 1) as usize,
                                      &message.output);
-            }
+            },
+            MsgType::Finish(ref _finish) => {
+            },
         }
 
         return vec![worker::Action::Ack];
@@ -343,7 +345,7 @@ mod tests {
         };
         let mut job = LogMessage {
             from: make_from("foo"),
-            message: Right(logmsg.clone()),
+            message: MsgType::Msg(logmsg.clone()),
         };
 
         let p = TestScratch::new_dir("log-message-collector-path_for_log");
@@ -354,7 +356,7 @@ mod tests {
                        worker.consumer(&
                                        LogMessage {
                                            from: make_from("foo"),
-                                           message: Left(BuildLogStart {
+                                           message: MsgType::Start(BuildLogStart {
                                                attempt_id: String::from("my-attempt-id"),
                                                identity: String::from("my-identity"),
                                                system: String::from("foobar-x8664"),
@@ -369,14 +371,14 @@ mod tests {
 
             logmsg.line_number = 5;
             logmsg.output = String::from("line-5");
-            job.message = Right(logmsg.clone());
+            job.message = MsgType::Msg(logmsg.clone());
             assert_eq!(vec![worker::Action::Ack], worker.consumer(&job));
 
             job.from.attempt_id = String::from("my-other-attempt");
             logmsg.attempt_id = String::from("my-other-attempt");
             logmsg.line_number = 3;
             logmsg.output = String::from("line-3");
-            job.message = Right(logmsg.clone());
+            job.message = MsgType::Msg(logmsg.clone());
             assert_eq!(vec![worker::Action::Ack], worker.consumer(&job));
         }
 


### PR DESCRIPTION
Send BuildResult messages to the log queue for collection. Hint: we may want to make the github comment poster no longer listen on the build-results queue, but instead of the log queue. This is a bit complicated, though, since the current design of the build-result queue makes it much more likely to only post one comment per result. Note this doesn't SAVE the results of the build, but gets the builders sending the data.