### PR TITLE
Add brainrape to config.extra-known-users

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -1,4 +1,5 @@
 [
+    "brainrape",
     "bhipple",
     "dywedir",
     "edef1c",


### PR DESCRIPTION
Hi!
I maintain Idris packages here:
https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/idris-modules
They are not included in the main package set, so won't build automatically. I'd like to occasionally trigger some builds. 
Please consider adding me.
Thanks!