### PR TITLE
Add etu to config.extra-known-users

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -3,6 +3,7 @@
     "bhipple",
     "dywedir",
     "edef1c",
+    "etu",
     "Ekleog",
     "infinisil",
     "Ma27",


### PR DESCRIPTION
Would like to be able to run builds to test things faster and such.

@Mic92 said that I should add myself as a known-user https://github.com/NixOS/nixpkgs/pull/38654