### PR TITLE
Add timokau to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -54,6 +54,7 @@
             "ryantm",
             "shlevy",
             "srhb",
+            "timokau",
             "veprbl",
             "vcunat",
             "yegortimoshenko",


### PR DESCRIPTION
I'm opening a lot of PRs recently and would love to be able to check those changes against more platforms than `x86_64-linux`. "trusted" might be optimistic, but testing on darwin would be nice so I thought I'd try.

I'll gladly open another PR for "known" instead of "trusted" if you think thats better for now.