### PR TITLE
Make ofborg able to (un)label issues and PRs

### DIFF
--- a/ofborg/src/bin/github-labeler.rs
+++ b/ofborg/src/bin/github-labeler.rs
@@ -1,0 +1,100 @@
+extern crate ofborg;
+extern crate amqp;
+extern crate env_logger;
+
+extern crate hyper;
+extern crate hubcaps;
+extern crate hyper_native_tls;
+
+
+use std::collections::HashMap;
+use std::env;
+
+use amqp::Basic;
+
+use ofborg::config;
+use ofborg::worker;
+use ofborg::tasks;
+use ofborg::easyamqp;
+use ofborg::easyamqp::TypedWrappers;
+
+
+fn main() {
+    let mut label_map = HashMap::new();
+    label_map.insert("bug".to_owned(), "0.kind: bug".to_owned());
+    label_map.insert("enhancement".to_owned(), "0.kind: enhancement".to_owned());
+    label_map.insert("question".to_owned(), "0.kind: question".to_owned());
+    label_map.insert("regression".to_owned(), "0.kind: regression".to_owned());
+    // TODO: add more labels (this is an implicit whitelist) and load from config file
+
+    let cfg = config::load(env::args().nth(1).unwrap().as_ref());
+    ofborg::setup_log();
+
+    let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
+    let mut channel = session.open_channel(1).unwrap();
+
+    // TODO: I have no idea what I'm doing, this is basically github-comment-parser
+    // adapted in a "let's hope this will work" fashion.
+    channel
+        .declare_exchange(easyamqp::ExchangeConfig {
+            exchange: "label-jobs".to_owned(),
+            exchange_type: easyamqp::ExchangeType::Fanout,
+            passive: false,
+            durable: true,
+            auto_delete: false,
+            no_wait: false,
+            internal: false,
+            arguments: None,
+        })
+        .unwrap();
+
+    channel
+        .declare_queue(easyamqp::QueueConfig {
+            queue: "label-jobs".to_owned(),
+            passive: false,
+            durable: true,
+            exclusive: false,
+            auto_delete: false,
+            no_wait: false,
+            arguments: None,
+        })
+        .unwrap();
+
+    channel
+        .bind_queue(easyamqp::BindQueueConfig {
+            queue: "label-jobs".to_owned(),
+            exchange: "label-jobs".to_owned(),
+            routing_key: None,
+            no_wait: false,
+            arguments: None,
+        })
+        .unwrap();
+
+    channel.basic_prefetch(1).unwrap();
+    channel
+        .consume(
+            worker::new(tasks::githublabeler::GitHubLabeler::new(
+                cfg.github(),
+                label_map,
+            )),
+            easyamqp::ConsumeConfig {
+                queue: "label-jobs".to_owned(),
+                consumer_tag: format!("{}-github-labeler", cfg.whoami()),
+                no_local: false,
+                no_ack: false,
+                no_wait: false,
+                exclusive: false,
+                arguments: None,
+            },
+        )
+        .unwrap();
+
+    channel.start_consuming();
+
+    println!("Finished consuming?");
+
+    channel.close(200, "Bye").unwrap();
+    println!("Closed the channel");
+    session.close(200, "Good Bye");
+    println!("Closed the session... EOF");
+}

--- a/ofborg/src/message/labeljob.rs
+++ b/ofborg/src/message/labeljob.rs
@@ -1,0 +1,9 @@
+use ofborg::message::{Pr, Repo};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LabelJob {
+    pub repo: Repo,
+    pub pr: Pr,
+    pub add_labels: Vec<String>,
+    pub remove_labels: Vec<String>,
+}

--- a/ofborg/src/message/mod.rs
+++ b/ofborg/src/message/mod.rs
@@ -1,6 +1,7 @@
 mod common;
 pub mod buildjob;
 pub mod buildresult;
+pub mod labeljob;
 pub mod massrebuildjob;
 pub mod buildlogmsg;
 

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -8,7 +8,7 @@ use ofborg::acl;
 use serde_json;
 
 use hubcaps;
-use ofborg::message::{Repo, Pr, buildjob, massrebuildjob};
+use ofborg::message::{Repo, Pr, buildjob, labeljob, massrebuildjob};
 use ofborg::worker;
 use ofborg::commentparser;
 use amqp::protocol::basic::{Deliver, BasicProperties};
@@ -137,7 +137,18 @@ impl worker::SimpleWorker for GitHubCommentWorker {
                         ));
                     }
                     commentparser::Instruction::Label(add_labels, remove_labels) => {
-                        unimplemented!()
+                        let msg = labeljob::LabelJob {
+                            repo: repo_msg.clone(),
+                            pr: pr_msg.clone(),
+                            add_labels,
+                            remove_labels,
+                        };
+
+                        response.push(worker::publish_serde_action(
+                            None,
+                            Some("label-jobs".to_owned()),
+                            &msg,
+                        ));
                     }
                 }
             }

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -136,7 +136,9 @@ impl worker::SimpleWorker for GitHubCommentWorker {
                             &msg,
                         ));
                     }
-
+                    commentparser::Instruction::Label(add_labels, remove_labels) => {
+                        unimplemented!()
+                    }
                 }
             }
         }

--- a/ofborg/src/tasks/githublabeler.rs
+++ b/ofborg/src/tasks/githublabeler.rs
@@ -1,0 +1,64 @@
+extern crate amqp;
+extern crate env_logger;
+
+use std::collections::HashMap;
+
+use serde_json;
+
+use hubcaps;
+use ofborg::message::labeljob::LabelJob;
+use ofborg::tasks::massrebuilder::update_labels;
+use ofborg::worker;
+use amqp::protocol::basic::{Deliver, BasicProperties};
+
+
+pub struct GitHubLabeler {
+    github: hubcaps::Github,
+    labels: HashMap<String, String>,
+}
+
+impl GitHubLabeler {
+    pub fn new(github: hubcaps::Github, labels: HashMap<String, String>) -> GitHubLabeler {
+        return GitHubLabeler { github, labels };
+    }
+}
+
+impl worker::SimpleWorker for GitHubLabeler {
+    type J = LabelJob;
+
+    fn msg_to_job(
+        &mut self,
+        _: &Deliver,
+        _: &BasicProperties,
+        body: &Vec<u8>,
+    ) -> Result<Self::J, String> {
+        return match serde_json::from_slice(body) {
+            Ok(e) => Ok(e),
+            Err(e) => {
+                Err(format!(
+                    "Failed to deserialize LabelJob: {:?}, err: {:}",
+                    String::from_utf8_lossy(&body.clone()),
+                    e
+                ))
+            }
+        };
+    }
+
+    fn consumer(&mut self, job: &LabelJob) -> worker::Actions {
+        let add_labels = job.add_labels
+            .iter()
+            .filter_map(|x| self.labels.get(x).cloned())
+            .collect::<Vec<String>>();
+        let remove_labels = job.remove_labels
+            .iter()
+            .filter_map(|x| self.labels.get(x).cloned())
+            .collect::<Vec<String>>();
+
+        let repo = self.github.repo(job.repo.owner.clone(), job.repo.name.clone());
+        let issue = repo.issue(job.pr.number);
+
+        update_labels(&issue, add_labels, remove_labels);
+
+        return vec![worker::Action::Ack];
+    }
+}

--- a/ofborg/src/tasks/mod.rs
+++ b/ofborg/src/tasks/mod.rs
@@ -3,6 +3,7 @@ pub mod build;
 pub mod massrebuilder;
 pub mod githubcommentfilter;
 pub mod githubcommentposter;
+pub mod githublabeler;
 pub mod statscollector;
 pub mod log_message_collector;
 pub mod evaluationfilter;


### PR DESCRIPTION
This PR adds an `@ofborg label [label-id]` command that tags the PR/issue as `label` (after a `label-id` → `label` translation phase), via a dedicated worker so that response can be instantaneous even if the builders are all in use.


Still missing:
 * Authentication
 * Having someone who actually knows a bit about AMQP proofread the code
 * Loading the tag id -> tag association from a file

Review should be easier commit-by-commit :)

(This builds upon #124)