### PR TITLE
Export NIX_REMOTE in the shell so that building on recent NixOS doesn't fail

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,8 @@ let
       checkPhase() {
           ( cd "${builtins.toString ./.}/ofborg" && cargo test --lib )
       }
+
+      export NIX_REMOTE=daemon
     '';
 
     HISTFILE = "${toString ./.}/.bash_hist";


### PR DESCRIPTION
I guess this is “fixing” the symptoms and not the cause, but…?