### PR TITLE
Default to building with nix2

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nix {}, useNix1 ? true }:
+{ pkgs ? import ./nix {}, useNix1 ? false }:
 
 let
   inherit (pkgs) stdenv;


### PR DESCRIPTION
Nix is now mostly used in its version 2, so let's switch to that.