### PR TITLE
abort mass-rebuilder if less than 8Gb of memory is "available"

### DIFF
--- a/nix/ofborg-carnix.nix
+++ b/nix/ofborg-carnix.nix
@@ -608,6 +608,16 @@ rec {
     sha256 = "1pimp7fpvillhz06xz0k6450h9nis3ab6h1j2hzrzykrpxs2qnyg";
     inherit dependencies buildDependencies features;
   };
+  sys_info_0_5_6_ = { dependencies?[], buildDependencies?[], features?[] }: buildRustCrate {
+    crateName = "sys-info";
+    version = "0.5.6";
+    authors = [ "Siyu Wang <FillZpp.pub@gmail.com>" ];
+    sha256 = "118ma1x3gnlm5jxxgi0bp8bskka5npnwn4f8m93zncbrbmzic2ff";
+    libPath = "lib.rs";
+    libName = "sys_info";
+    build = "build.rs";
+    inherit dependencies buildDependencies features;
+  };
   tempdir_0_3_7_ = { dependencies?[], buildDependencies?[], features?[] }: buildRustCrate {
     crateName = "tempdir";
     version = "0.3.7";
@@ -1440,7 +1450,7 @@ rec {
     num_cpus_1_8_0.default = (f.num_cpus_1_8_0.default or true);
   }) [ libc_0_2_40_features ];
   ofborg_0_1_5 = { features?(ofborg_0_1_5_features {}) }: ofborg_0_1_5_ {
-    dependencies = mapFeatures features ([ amqp_0_1_0 either_1_5_0 env_logger_0_4_3 fs2_0_4_3 hubcaps_0_3_16 hyper_0_10_13 hyper_native_tls_0_2_4 log_0_3_8 lru_cache_0_1_1 md5_0_3_7 nom_4_0_0_beta3 serde_1_0_43 serde_derive_1_0_43 serde_json_1_0_16 tempfile_2_2_0 uuid_0_4_0 ]);
+    dependencies = mapFeatures features ([ amqp_0_1_0 either_1_5_0 env_logger_0_4_3 fs2_0_4_3 hubcaps_0_3_16 hyper_0_10_13 hyper_native_tls_0_2_4 log_0_3_8 lru_cache_0_1_1 md5_0_3_7 nom_4_0_0_beta3 serde_1_0_43 serde_derive_1_0_43 serde_json_1_0_16 sys_info_0_5_6 tempfile_2_2_0 uuid_0_4_0 ]);
   };
   ofborg_0_1_5_features = f: updateFeatures f (rec {
     amqp_0_1_0.default = true;
@@ -1458,10 +1468,11 @@ rec {
     serde_1_0_43.default = true;
     serde_derive_1_0_43.default = true;
     serde_json_1_0_16.default = true;
+    sys_info_0_5_6.default = true;
     tempfile_2_2_0.default = true;
     uuid_0_4_0.default = true;
     uuid_0_4_0.v4 = true;
-  }) [ amqp_0_1_0_features either_1_5_0_features env_logger_0_4_3_features fs2_0_4_3_features hubcaps_0_3_16_features hyper_0_10_13_features hyper_native_tls_0_2_4_features log_0_3_8_features lru_cache_0_1_1_features md5_0_3_7_features nom_4_0_0_beta3_features serde_1_0_43_features serde_derive_1_0_43_features serde_json_1_0_16_features tempfile_2_2_0_features uuid_0_4_0_features ];
+  }) [ amqp_0_1_0_features either_1_5_0_features env_logger_0_4_3_features fs2_0_4_3_features hubcaps_0_3_16_features hyper_0_10_13_features hyper_native_tls_0_2_4_features log_0_3_8_features lru_cache_0_1_1_features md5_0_3_7_features nom_4_0_0_beta3_features serde_1_0_43_features serde_derive_1_0_43_features serde_json_1_0_16_features sys_info_0_5_6_features tempfile_2_2_0_features uuid_0_4_0_features ];
   openssl_0_9_24 = { features?(openssl_0_9_24_features {}) }: openssl_0_9_24_ {
     dependencies = mapFeatures features ([ bitflags_0_9_1 foreign_types_0_3_2 lazy_static_1_0_0 libc_0_2_40 openssl_sys_0_9_28 ]);
     features = mkFeatures (features.openssl_0_9_24 or {});
@@ -1822,6 +1833,15 @@ rec {
       (syn_0_13_1.printing or false);
     unicode_xid_0_1_0.default = true;
   }) [ proc_macro2_0_3_7_features quote_0_5_2_features unicode_xid_0_1_0_features ];
+  sys_info_0_5_6 = { features?(sys_info_0_5_6_features {}) }: sys_info_0_5_6_ {
+    dependencies = mapFeatures features ([ libc_0_2_40 ]);
+    buildDependencies = mapFeatures features ([ cc_1_0_10 ]);
+  };
+  sys_info_0_5_6_features = f: updateFeatures f (rec {
+    cc_1_0_10.default = true;
+    libc_0_2_40.default = true;
+    sys_info_0_5_6.default = (f.sys_info_0_5_6.default or true);
+  }) [ libc_0_2_40_features cc_1_0_10_features ];
   tempdir_0_3_7 = { features?(tempdir_0_3_7_features {}) }: tempdir_0_3_7_ {
     dependencies = mapFeatures features ([ rand_0_4_2 remove_dir_all_0_5_1 ]);
   };

--- a/ofborg/Cargo.lock
+++ b/ofborg/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -616,6 +617,15 @@ dependencies = [
  "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -873,6 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
 "checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
 "checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "617f594d3869801871433390254b4a79f2a18176d7f4ad5784fa990bc8c12986"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -25,6 +25,7 @@ hyper = "0.10.*"
 hyper-native-tls = "0.2.4"
 lru-cache = "0.1.1"
 nom = "4.0.0-beta3"
+sys-info = "0.5.6"
 
 #[patch.crates-io]
 #amq-proto = { path = "rust-amq-proto" }

--- a/ofborg/src/bin/mass-rebuilder.rs
+++ b/ofborg/src/bin/mass-rebuilder.rs
@@ -1,9 +1,11 @@
 extern crate ofborg;
 extern crate amqp;
 extern crate env_logger;
+extern crate sys_info;
 
 use std::env;
 use std::path::Path;
+use std::process;
 use ofborg::tasks;
 use ofborg::config;
 use ofborg::checkout;
@@ -15,12 +17,18 @@ use ofborg::easyamqp;
 use ofborg::easyamqp::TypedWrappers;
 
 fn main() {
+    let memory_info = sys_info::mem_info().expect("Unable to get memory information from OS");
+
+    if memory_info.avail < 8 * 1024 * 1024 { // seems this stuff is in kilobytes?
+        println!("Less than 8Gb of memory available (got {:.2}Gb). Aborting.", (memory_info.avail as f32) / 1024.0 / 1024.0 );
+        process::exit(1);
+    };
+
     let cfg = config::load(env::args().nth(1).unwrap().as_ref());
 
     ofborg::setup_log();
 
     println!("Hello, world!");
-
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
     println!("Connected to rabbitmq");


### PR DESCRIPTION
…where available is defined as "how much RAM can the kernel give to an application immediately without having to reach for swap".

@grahamc, are you sure we shouldn't instead check for total memory assuming other sources of memory usage can be pushed to swap?

Coded up at the London Rust meetup https://www.meetup.com/Rust-London-User-Group/events/250178008/

