### PR TITLE
Add knedlsepp to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -38,6 +38,7 @@
             "jb55",
             "joachifm",
             "jtojnar",
+            "knedlsepp",
             "lassulus",
             "lheckemann",
             "lnl7",


### PR DESCRIPTION
As my contributions revolve mostly around darwin fixes, automatic ofborg builds would be of great help. While I'm not sure how to qualify as a *well known, trusted member of the community*, Mic92 suggested to me to simply ask for approval: https://github.com/NixOS/nixpkgs/pull/40802#issuecomment-390470101
