### PR TITLE
massrebuilder: return the outpath instead of .drv

### DIFF
--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofborg"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Graham Christensen <graham@grahamc.com>"]
 include = ["Cargo.toml", "Cargo.lock", "src", "test-srcs", "build.rs"]
 build = "build.rs"


### PR DESCRIPTION
Currently some stdenv changes might get laballed as rebuilds even if the
drv changes don't have an effect on the output path (eg: meta attribute
changes).

Fixes #187