### PR TITLE
 eval-checker: use explicit 'nixpkgs' argument for release.nix expressions

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiation() {
+    fn instantiation_success() {
         let ret: Result<File, File> = nix().safely(
             Operation::Instantiate,
             passing_eval_path().as_path(),
@@ -690,6 +690,25 @@ mod tests {
                 "the result might be removed by the garbage collector",
                 "-failed.drv",
                 "-success.drv",
+            ],
+        );
+    }
+
+    #[test]
+    fn instantiation_nixpkgs_restricted_mode() {
+        let ret: Result<File, File> = nix().safely(
+            Operation::Instantiate,
+            individual_eval_path().as_path(),
+            vec![String::from("-A"), String::from("nixpkgs-restricted-mode")],
+            true,
+        );
+
+        assert_run(
+            ret,
+            Expect::Fail,
+            vec![
+                "access to path '/fake'",
+                "is forbidden in restricted mode",
             ],
         );
     }

--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -348,6 +348,9 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixos-options",
                 nix::Operation::Instantiate,
                 vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("./."),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("options"),
@@ -359,6 +362,9 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixos-manual",
                 nix::Operation::Instantiate,
                 vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("./."),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -370,6 +376,9 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-manual",
                 nix::Operation::Instantiate,
                 vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -381,6 +390,9 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-tarball",
                 nix::Operation::Instantiate,
                 vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("tarball"),
@@ -392,6 +404,9 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-unstable-jobset",
                 nix::Operation::Instantiate,
                 vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("unstable"),

--- a/ofborg/test-srcs/eval-mixed-failure/default.nix
+++ b/ofborg/test-srcs/eval-mixed-failure/default.nix
@@ -1,6 +1,14 @@
 let
+  fetchGit = builtins.fetchGit or (path: assert builtins.trace ''
+    error: access to path '/fake' is forbidden in restricted mode
+  '' false; path);
+
   nix = import <nix/config.nix>;
-in rec {
+in
+
+{ nixpkgs ? fetchGit /fake }:
+
+rec {
   success = derivation {
     name = "success";
     system = builtins.currentSystem;
@@ -26,6 +34,15 @@ in rec {
     args = [
       "-c"
       "echo this ones cool" ];
+  };
+
+  nixpkgs-restricted-mode = derivation {
+    name = "nixpkgs-restricted-mode-fetchgit";
+    system = builtins.currentSystem;
+    builder = nix.shell;
+    args = [
+      "-c"
+      "echo hi; echo ${toString nixpkgs} > $out" ];
   };
 
   fails-instantiation = assert builtins.trace ''


### PR DESCRIPTION
Abstracting the evaluation of the release.nix expressions and attributes would be nicer, but this should fix the evaluation issues.

~~The test doesn't work yet, but I also had trouble reproducing the behaviour interactively.~~