### PR TITLE
Disable aliases in OfBorg's outPaths

### DIFF
--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -16,6 +16,7 @@ let
           allowBroken = true;
           allowUnfree = true;
           allowInsecurePredicate = x: true;
+          allowAliases = false;
           checkMeta = checkMeta;
 
           handleEvalIssue = reason: errormsg:


### PR DESCRIPTION
This will give more immediate feedback for us when a PR introduces an alias.