### PR TITLE
detect timedout builds

### DIFF
--- a/ofborg/src/message/buildresult.rs
+++ b/ofborg/src/message/buildresult.rs
@@ -1,5 +1,15 @@
 use ofborg::message::{Pr, Repo};
 
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum BuildStatus {
+    Skipped,
+    Success,
+    Failure,
+    TimedOut,
+    UnexpectedError { err: String },
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BuildResult {
     pub repo: Repo,
@@ -8,7 +18,8 @@ pub struct BuildResult {
     pub output: Vec<String>,
     pub attempt_id: String,
     pub request_id: Option<String>,
-    pub success: Option<bool>,
+    pub success: Option<bool>, // replaced by status
+    pub status: Option<BuildStatus>,
     pub skipped_attrs: Option<Vec<String>>,
     pub attempted_attrs: Option<Vec<String>>,
 }

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -8,7 +8,9 @@ use std::process::{Command, Stdio};
 use tempfile::tempfile;
 use std::io::BufReader;
 use std::io::BufRead;
+use ofborg::asynccmd::{AsyncCmd, SpawnedAsyncCmd};
 use ofborg::partition_result;
+
 
 #[derive(Clone, Debug)]
 pub enum Operation {
@@ -162,7 +164,17 @@ impl Nix {
         return self.run(cmd, true);
     }
 
-    pub fn safely_build_attrs_cmd(
+    pub fn safely_build_attrs_async(
+        &self,
+        nixpkgs: &Path,
+        file: &str,
+        attrs: Vec<String>,
+    ) -> SpawnedAsyncCmd {
+        AsyncCmd::new(self.safely_build_attrs_cmd(nixpkgs, file, attrs))
+            .spawn()
+    }
+
+    fn safely_build_attrs_cmd(
         &self,
         nixpkgs: &Path,
         file: &str,
@@ -175,7 +187,7 @@ impl Nix {
             attrargs.push(attr);
         }
 
-        return self.safe_command(Operation::Build, nixpkgs, attrargs);
+        self.safe_command(Operation::Build, nixpkgs, attrargs)
     }
 
     pub fn safely(

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -369,12 +369,12 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             can_build.clone(),
         );
 
-        for line in spawned.lines().iter() {
+        for line in spawned.lines() {
             actions.log_line(&line);
         }
 
         let success = match spawned.wait() {
-            Ok(Some(Ok(status))) => status.success(),
+            Ok(status) => status.success(),
             e => {
                 println!("Failed on the interior command: {:?}", e);
                 false

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -5,7 +5,6 @@ extern crate env_logger;
 use uuid::Uuid;
 
 use std::collections::VecDeque;
-use ofborg::asynccmd::AsyncCmd;
 use ofborg::checkout;
 use ofborg::message::buildjob;
 use ofborg::message::buildresult;
@@ -364,15 +363,11 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             return;
         }
 
-        let cmd = self.nix.safely_build_attrs_cmd(
+        let mut spawned = self.nix.safely_build_attrs_async(
             refpath.as_ref(),
             buildfile,
             can_build.clone(),
         );
-
-        println!("About to execute {:?}", cmd);
-        let acmd = AsyncCmd::new(cmd);
-        let mut spawned = acmd.spawn();
 
         for line in spawned.lines().iter() {
             actions.log_line(&line);

--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 
 use ofborg::writetoline::LineWriter;
 use ofborg::message::buildlogmsg::{BuildLogStart, BuildLogMsg};
-use ofborg::message::buildresult::BuildResult;
+use ofborg::message::buildresult::{BuildStatus, BuildResult};
 use ofborg::worker;
 use amqp::protocol::basic::{Deliver, BasicProperties};
 
@@ -445,6 +445,7 @@ mod tests {
                                                output: vec![],
                                                attempt_id: "attempt-id-foo".to_owned(),
                                                request_id: Some("bogus-request-id".to_owned()),
+                                               status: Some(BuildStatus::Success),
                                                success: Some(true),
                                                attempted_attrs: Some(vec!["foo".to_owned()]),
                                                skipped_attrs: Some(vec!["bar".to_owned()]),
@@ -478,6 +479,6 @@ mod tests {
         let mut s = String::new();
         pr.push("routing-key-foo/attempt-id-foo.result.json");
         File::open(pr).unwrap().read_to_string(&mut s).unwrap();
-        assert_eq!(&s, "{\"repo\":{\"owner\":\"NixOS\",\"name\":\"ofborg\",\"full_name\":\"NixOS/ofborg\",\"clone_url\":\"https://github.com/nixos/ofborg.git\"},\"pr\":{\"target_branch\":\"scratch\",\"number\":42,\"head_sha\":\"6dd9f0265d52b946dd13daf996f30b64e4edb446\"},\"system\":\"x86_64-linux\",\"output\":[],\"attempt_id\":\"attempt-id-foo\",\"request_id\":\"bogus-request-id\",\"success\":true,\"skipped_attrs\":[\"bar\"],\"attempted_attrs\":[\"foo\"]}");
+        assert_eq!(&s, "{\"repo\":{\"owner\":\"NixOS\",\"name\":\"ofborg\",\"full_name\":\"NixOS/ofborg\",\"clone_url\":\"https://github.com/nixos/ofborg.git\"},\"pr\":{\"target_branch\":\"scratch\",\"number\":42,\"head_sha\":\"6dd9f0265d52b946dd13daf996f30b64e4edb446\"},\"system\":\"x86_64-linux\",\"output\":[],\"attempt_id\":\"attempt-id-foo\",\"request_id\":\"bogus-request-id\",\"success\":true,\"status\":\"Success\",\"skipped_attrs\":[\"bar\"],\"attempted_attrs\":[\"foo\"]}");
     }
 }


### PR DESCRIPTION
This should change the error messages for timed out builds to something like.

```
Timed out, unknown build status on x86_64-linux
```

I think this is fully backwards compatible, allowing builders to continue sending build results in the old format, while newer versions send more information using the new format. This could be cleaned up once all the infrastructure is updated.