### PR TITLE
Don't trigger events on deleted comments

### DIFF
--- a/ofborg/src/ghevent/issuecomment.rs
+++ b/ofborg/src/ghevent/issuecomment.rs
@@ -2,7 +2,16 @@ use ofborg::ghevent::{Comment, Repository, Issue};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IssueComment {
+    pub action: IssueCommentAction,
     pub comment: Comment,
     pub repository: Repository,
     pub issue: Issue,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all="snake_case")]
+pub enum IssueCommentAction {
+    Created,
+    Edited,
+    Deleted,
 }

--- a/ofborg/src/ghevent/mod.rs
+++ b/ofborg/src/ghevent/mod.rs
@@ -2,6 +2,6 @@ mod common;
 mod issuecomment;
 mod pullrequestevent;
 
-pub use self::issuecomment::IssueComment;
+pub use self::issuecomment::{IssueComment,IssueCommentAction};
 pub use self::pullrequestevent::{PullRequest, PullRequestEvent, PullRequestAction, PullRequestState};
 pub use self::common::{Issue, Repository, User, Comment};

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -50,6 +50,10 @@ impl worker::SimpleWorker for GitHubCommentWorker {
     }
 
     fn consumer(&mut self, job: &ghevent::IssueComment) -> worker::Actions {
+        if job.action == ghevent::IssueCommentAction::Deleted {
+            return vec![worker::Action::Ack];
+        }
+
         let instructions = commentparser::parse(&job.comment.body);
         if instructions == None {
             return vec![worker::Action::Ack];


### PR DESCRIPTION
According to
https://developer.github.com/v3/activity/events/types/#issuecommentevent
we should just filter out delete actions.

Closes #156