### PR TITLE
Add kalbasit to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -40,6 +40,7 @@
             "jb55",
             "joachifm",
             "jtojnar",
+            "kalbasit",
             "knedlsepp",
             "lassulus",
             "lheckemann",


### PR DESCRIPTION
I was trying to review https://github.com/NixOS/nixpkgs/pull/45006 and I quickly realized that I can't build on Darwin, the target of this PR.