### PR TITLE
Move infinisil to trusted_users

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -9,7 +9,6 @@
     "etu",
     "fgaz",
     "grwlf",
-    "infinisil",
     "imalsogreg",
     "jlesquembre",
     "johanot",

--- a/config.public.json
+++ b/config.public.json
@@ -37,6 +37,7 @@
             "gilligan",
             "globin",
             "grahamc",
+            "infinisil",
             "jb55",
             "joachifm",
             "jtojnar",


### PR DESCRIPTION
Would like to help with getting packages to build properly on Darwin :)

Btw: I almost committed the file with using tabs instead of spaces. Would be nice to add an [`.editorconfig`](https://editorconfig.org/) file, such that editors (with the plugin installed) take care of such things automatically. nixpkgs also uses this