### PR TITLE
Add etu to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -28,6 +28,7 @@
             "domenkozar",
             "dotlambda",
             "dtzwill",
+            "etu",
             "edolstra",
             "ericson2314",
             "flokli",


### PR DESCRIPTION
Would be useful for me to be able to trigger builds on darwin.