### PR TITLE
add new eval checker for the package list with allowAliases = false

### DIFF
--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -332,6 +332,19 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
             ),
 
             EvalChecker::new(
+                "package-list-no-aliases",
+                nix::Operation::QueryPackagesJSON,
+                vec![
+                    String::from("--file"),
+                    String::from("."),
+                    String::from("--arg"),
+                    String::from("config"),
+                    String::from("{ allowAliases = false; }"),
+                ],
+                self.nix.clone()
+            ),
+
+            EvalChecker::new(
                 "nixos-options",
                 nix::Operation::Instantiate,
                 vec![


### PR DESCRIPTION
closes #248

By checking the package list without aliases, we can make it more
likely that people do not introduce new aliases into `nixpkgs` without
removing them from the repository. Aliases are supposed to be for
backward compatibility.

Also, we can make sure this configuration option continues to work for
people. Noteably, this configuration option is used by
r-ryantm/nixpkgs-update to avoid submitting duplicate pull requests
for the package and its alias, and to use the correct (non-alaised)
name in the pull request.