### PR TITLE
Add florianjacob to extra-known-users.json

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -9,6 +9,7 @@
     "Enzime",
     "etu",
     "fgaz",
+    "florianjacob",
     "grwlf",
     "imalsogreg",
     "jlesquembre",


### PR DESCRIPTION
Is this the right thing to do to be able to run commands like `@GrahamcOfBorg test matrix-synapse` by myself as e.g. in https://github.com/NixOS/nixpkgs/pull/41728#issuecomment-395954947 ? :bowing_man: 