### PR TITLE
Prohibit use of nixpkgs.extend from inside Nixpkgs

### DIFF
--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -345,6 +345,19 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
             ),
 
             EvalChecker::new(
+                "package-list-no-extend",
+                nix::Operation::QueryPackagesJSON,
+                vec![
+                    String::from("--file"),
+                    String::from("."),
+                    String::from("--arg"),
+                    String::from("overlays"),
+                    String::from("[(self: super: { extend = abort ''The pkgs.extend function should not be used inside Nixpkgs. Extensive use decreases performance and complicates the package set. If absolutely necessary, this restriction may be lifted.''; })]"),
+                ],
+                self.nix.clone()
+            ),
+
+            EvalChecker::new(
                 "nixos-options",
                 nix::Operation::Instantiate,
                 vec![

--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -332,7 +332,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
             ),
 
             EvalChecker::new(
-                "package-list-no-aliases",
+                "package-list-strictly",
                 nix::Operation::QueryPackagesJSON,
                 vec![
                     String::from("--file"),
@@ -340,16 +340,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                     String::from("--arg"),
                     String::from("config"),
                     String::from("{ allowAliases = false; }"),
-                ],
-                self.nix.clone()
-            ),
-
-            EvalChecker::new(
-                "package-list-no-extend",
-                nix::Operation::QueryPackagesJSON,
-                vec![
-                    String::from("--file"),
-                    String::from("."),
                     String::from("--arg"),
                     String::from("overlays"),
                     String::from("[(self: super: { extend = abort ''The pkgs.extend function should not be used inside Nixpkgs. Extensive use decreases performance and complicates the package set. If absolutely necessary, this restriction may be lifted.''; })]"),


### PR DESCRIPTION
`extend` is a new function on Nixpkgs that lets users extend Nixpkgs with overlays after calling the Nixpkgs function. This makes Nixpkgs similar to package sets that were created with `lib.makeExtensible`.

Nixpkgs should probably not start using this, because re-evaluating the Nixpkgs is somewhat expensive.

See https://github.com/NixOS/nixpkgs/pull/47430#issuecomment-432254467

I am not familiar with ofborg and I wasn't sure how to test this, so it is mostly cargo culted. I did test the ad-hoc overlay itself.
