### PR TITLE
Move thoughtpolice to trusted users

### DIFF
--- a/config.known-users.json
+++ b/config.known-users.json
@@ -105,7 +105,6 @@
       "tadfisher",
       "teto",
       "the-kenny",
-      "thoughtpolice",
       "ts468",
       "ttuegel",
       "unode",

--- a/config.public.json
+++ b/config.public.json
@@ -70,6 +70,7 @@
             "samueldr",
             "shlevy",
             "srhb",
+            "thoughtpolice",
             "timokau",
             "vbgl",
             "veprbl",


### PR DESCRIPTION
I'd like to trigger builds on Darwin for my PostgreSQL work (and other related things.)