### PR TITLE
Add jfrankenau to extra-known-users

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -21,6 +21,7 @@
     "geistesk",
     "grwlf",
     "imalsogreg",
+    "jfrankenau",
     "jlesquembre",
     "jluttine",
     "johanot",


### PR DESCRIPTION
To make the review process of my [PRs](https://github.com/NixOS/nixpkgs/pulls?utf8=%E2%9C%93&q=is:pr+author:jfrankenau) easier. Thank you.