### PR TITLE
Move c0bw3b to trusted users

### DIFF
--- a/config.known-users.json
+++ b/config.known-users.json
@@ -24,7 +24,6 @@
       "bjornfor",
       "bluescreen303",
       "brainrape",
-      "c0bw3b",
       "chaoflow",
       "cillianderoiste",
       "copumpkin",

--- a/config.public.json
+++ b/config.public.json
@@ -20,6 +20,7 @@
             "aneeshusa",
             "aszlig",
             "basvandijk",
+            "c0bw3b",
             "cleverca22",
             "copumpkin",
             "coreyoconnor",


### PR DESCRIPTION
Politely asking :smiley_cat: 
it would allow me to check Linux+Darwin package updates before merging into nixpkgs.

I understood that Darwin builds are not sandboxed properly so trusted users should be extra careful when invoking ofBorg.
I also keep in mind that builders have limited resources and that I should check https://monitoring.nix.ci before launching a potentially heavy job.

/cc @grahamc @LnL7 @Mic92 