### PR TITLE
Revert " eval-checker: use explicit 'nixpkgs' argument for release.nix expressions"

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn instantiation_success() {
+    fn instantiation() {
         let ret: Result<File, File> = nix().safely(
             Operation::Instantiate,
             passing_eval_path().as_path(),
@@ -690,25 +690,6 @@ mod tests {
                 "the result might be removed by the garbage collector",
                 "-failed.drv",
                 "-success.drv",
-            ],
-        );
-    }
-
-    #[test]
-    fn instantiation_nixpkgs_restricted_mode() {
-        let ret: Result<File, File> = nix().safely(
-            Operation::Instantiate,
-            individual_eval_path().as_path(),
-            vec![String::from("-A"), String::from("nixpkgs-restricted-mode")],
-            true,
-        );
-
-        assert_run(
-            ret,
-            Expect::Fail,
-            vec![
-                "access to path '/fake'",
-                "is forbidden in restricted mode",
             ],
         );
     }

--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -348,9 +348,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixos-options",
                 nix::Operation::Instantiate,
                 vec![
-                    String::from("--arg"),
-                    String::from("nixpkgs"),
-                    String::from("./."),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("options"),
@@ -362,9 +359,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixos-manual",
                 nix::Operation::Instantiate,
                 vec![
-                    String::from("--arg"),
-                    String::from("nixpkgs"),
-                    String::from("./."),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -376,9 +370,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-manual",
                 nix::Operation::Instantiate,
                 vec![
-                    String::from("--arg"),
-                    String::from("nixpkgs"),
-                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -390,9 +381,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-tarball",
                 nix::Operation::Instantiate,
                 vec![
-                    String::from("--arg"),
-                    String::from("nixpkgs"),
-                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("tarball"),
@@ -404,9 +392,6 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 "nixpkgs-unstable-jobset",
                 nix::Operation::Instantiate,
                 vec![
-                    String::from("--arg"),
-                    String::from("nixpkgs"),
-                    String::from("./."),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("unstable"),

--- a/ofborg/test-srcs/eval-mixed-failure/default.nix
+++ b/ofborg/test-srcs/eval-mixed-failure/default.nix
@@ -1,14 +1,6 @@
 let
-  fetchGit = builtins.fetchGit or (path: assert builtins.trace ''
-    error: access to path '/fake' is forbidden in restricted mode
-  '' false; path);
-
   nix = import <nix/config.nix>;
-in
-
-{ nixpkgs ? fetchGit /fake }:
-
-rec {
+in rec {
   success = derivation {
     name = "success";
     system = builtins.currentSystem;
@@ -34,15 +26,6 @@ rec {
     args = [
       "-c"
       "echo this ones cool" ];
-  };
-
-  nixpkgs-restricted-mode = derivation {
-    name = "nixpkgs-restricted-mode-fetchgit";
-    system = builtins.currentSystem;
-    builder = nix.shell;
-    args = [
-      "-c"
-      "echo hi; echo ${toString nixpkgs} > $out" ];
   };
 
   fails-instantiation = assert builtins.trace ''


### PR DESCRIPTION
Reverts NixOS/ofborg#189

> error: value is a path while a set was expected, at /var/lib/ofborg/checkout/repo/38dca4e3aa6bca43ea96d2fcc04e8229/mr-est/eval-0-gleber.ewr1.nix.ci/pkgs/top-level/make-tarball.nix:19:34