### PR TITLE
massrebuilder.rs: correct the shape of nixpkgs argument to release.nix

### DIFF
--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -350,7 +350,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
-                    String::from("./."),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("options"),
@@ -364,7 +364,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
-                    String::from("./."),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
                     String::from("./nixos/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -378,7 +378,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
-                    String::from("./."),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("manual"),
@@ -392,7 +392,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
-                    String::from("./."),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("tarball"),
@@ -406,7 +406,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
-                    String::from("./."),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
                     String::from("./pkgs/top-level/release.nix"),
                     String::from("-A"),
                     String::from("unstable"),


### PR DESCRIPTION
To allow restricted mode evaluation, the Nixpkgs path has to be passed on the command line; this PR fixes the shape of the argument (it needs to have the actual path as `outPath` and have a couple extra entries).