### PR TITLE
Add non-bogus completion times to GitHub checks

### DIFF
--- a/ofborg/Cargo.lock
+++ b/ofborg/Cargo.lock
@@ -111,6 +111,16 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +392,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +425,7 @@ name = "ofborg"
 version = "0.1.8"
 dependencies = [
  "amqp 0.1.0 (git+https://github.com/grahamc/rust-amqp.git)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,6 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
@@ -846,6 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"

--- a/ofborg/Cargo.nix
+++ b/ofborg/Cargo.nix
@@ -112,6 +112,7 @@ let crates = cratesIO // rec {
     build = "build.rs";
     dependencies = mapFeatures features ([
       (crates."amqp"."${deps."ofborg"."0.1.8"."amqp"}" deps)
+      (cratesIO.crates."chrono"."${deps."ofborg"."0.1.8"."chrono"}" deps)
       (cratesIO.crates."either"."${deps."ofborg"."0.1.8"."either"}" deps)
       (cratesIO.crates."env_logger"."${deps."ofborg"."0.1.8"."env_logger"}" deps)
       (cratesIO.crates."fs2"."${deps."ofborg"."0.1.8"."fs2"}" deps)
@@ -132,6 +133,7 @@ let crates = cratesIO // rec {
   };
   features_.ofborg."0.1.8" = deps: f: updateFeatures f (rec {
     amqp."${deps.ofborg."0.1.8".amqp}".default = true;
+    chrono."${deps.ofborg."0.1.8".chrono}".default = true;
     either."${deps.ofborg."0.1.8".either}".default = true;
     env_logger."${deps.ofborg."0.1.8".env_logger}".default = true;
     fs2."${deps.ofborg."0.1.8".fs2}".default = true;
@@ -154,6 +156,7 @@ let crates = cratesIO // rec {
     ];
   }) [
     (features_.amqp."${deps."ofborg"."0.1.8"."amqp"}" deps)
+    (cratesIO.features_.chrono."${deps."ofborg"."0.1.8"."chrono"}" deps)
     (cratesIO.features_.either."${deps."ofborg"."0.1.8"."either"}" deps)
     (cratesIO.features_.env_logger."${deps."ofborg"."0.1.8"."env_logger"}" deps)
     (cratesIO.features_.fs2."${deps."ofborg"."0.1.8"."fs2"}" deps)
@@ -225,6 +228,11 @@ rec {
   deps.byteorder."1.2.7" = {};
   deps.cc."1.0.25" = {};
   deps.cfg_if."0.1.6" = {};
+  deps.chrono."0.4.6" = {
+    num_integer = "0.1.39";
+    num_traits = "0.2.6";
+    time = "0.1.40";
+  };
   deps.core_foundation."0.2.3" = {
     core_foundation_sys = "0.2.3";
     libc = "0.2.44";
@@ -339,6 +347,9 @@ rec {
   deps.nom."4.1.1" = {
     memchr = "2.1.1";
   };
+  deps.num_integer."0.1.39" = {
+    num_traits = "0.2.6";
+  };
   deps.num_traits."0.1.43" = {
     num_traits = "0.2.6";
   };
@@ -348,6 +359,7 @@ rec {
   };
   deps.ofborg."0.1.8" = {
     amqp = "0.1.0";
+    chrono = "0.4.6";
     either = "1.5.0";
     env_logger = "0.4.3";
     fs2 = "0.4.3";

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -26,6 +26,7 @@ hyper-native-tls = "0.2.4"
 lru-cache = "0.1.1"
 nom = "4.0.0-beta3"
 sys-info = "0.5.6"
+chrono = "0.4.6"
 
 [patch.crates-io]
 #hubcaps = { path = "../hubcaps" }

--- a/ofborg/crates-io.list
+++ b/ofborg/crates-io.list
@@ -12,6 +12,7 @@ byteorder-0.5.3
 byteorder-1.2.7
 cc-1.0.25
 cfg-if-0.1.6
+chrono-0.4.6
 core-foundation-0.2.3
 core-foundation-sys-0.2.3
 either-1.5.0
@@ -45,6 +46,7 @@ memchr-2.1.1
 mime-0.2.6
 native-tls-0.1.5
 nom-4.1.1
+num-integer-0.1.39
 num-traits-0.1.43
 num-traits-0.2.6
 num_cpus-1.8.0

--- a/ofborg/crates-io.nix
+++ b/ofborg/crates-io.nix
@@ -388,6 +388,43 @@ rec {
 
 
 # end
+# chrono-0.4.6
+
+  crates.chrono."0.4.6" = deps: { features?(features_.chrono."0.4.6" deps {}) }: buildRustCrate {
+    crateName = "chrono";
+    version = "0.4.6";
+    authors = [ "Kang Seonghoon <public+rust@mearie.org>" "Brandon W Maister <quodlibetor@gmail.com>" ];
+    sha256 = "0cxgqgf4lknsii1k806dpmzapi2zccjpa350ns5wpb568mij096x";
+    dependencies = mapFeatures features ([
+      (crates."num_integer"."${deps."chrono"."0.4.6"."num_integer"}" deps)
+      (crates."num_traits"."${deps."chrono"."0.4.6"."num_traits"}" deps)
+    ]
+      ++ (if features.chrono."0.4.6".time or false then [ (crates.time."${deps."chrono"."0.4.6".time}" deps) ] else []));
+    features = mkFeatures (features."chrono"."0.4.6" or {});
+  };
+  features_.chrono."0.4.6" = deps: f: updateFeatures f (rec {
+    chrono = fold recursiveUpdate {} [
+      { "0.4.6".clock =
+        (f.chrono."0.4.6".clock or false) ||
+        (f.chrono."0.4.6".default or false) ||
+        (chrono."0.4.6"."default" or false); }
+      { "0.4.6".default = (f.chrono."0.4.6".default or true); }
+      { "0.4.6".time =
+        (f.chrono."0.4.6".time or false) ||
+        (f.chrono."0.4.6".clock or false) ||
+        (chrono."0.4.6"."clock" or false); }
+    ];
+    num_integer."${deps.chrono."0.4.6".num_integer}".default = (f.num_integer."${deps.chrono."0.4.6".num_integer}".default or false);
+    num_traits."${deps.chrono."0.4.6".num_traits}".default = (f.num_traits."${deps.chrono."0.4.6".num_traits}".default or false);
+    time."${deps.chrono."0.4.6".time}".default = true;
+  }) [
+    (features_.num_integer."${deps."chrono"."0.4.6"."num_integer"}" deps)
+    (features_.num_traits."${deps."chrono"."0.4.6"."num_traits"}" deps)
+    (features_.time."${deps."chrono"."0.4.6"."time"}" deps)
+  ];
+
+
+# end
 # core-foundation-0.2.3
 
   crates.core_foundation."0.2.3" = deps: { features?(features_.core_foundation."0.2.3" deps {}) }: buildRustCrate {
@@ -1289,6 +1326,44 @@ rec {
     ];
   }) [
     (features_.memchr."${deps."nom"."4.1.1"."memchr"}" deps)
+  ];
+
+
+# end
+# num-integer-0.1.39
+
+  crates.num_integer."0.1.39" = deps: { features?(features_.num_integer."0.1.39" deps {}) }: buildRustCrate {
+    crateName = "num-integer";
+    version = "0.1.39";
+    authors = [ "The Rust Project Developers" ];
+    sha256 = "1f42ls46cghs13qfzgbd7syib2zc6m7hlmv1qlar6c9mdxapvvbg";
+    build = "build.rs";
+    dependencies = mapFeatures features ([
+      (crates."num_traits"."${deps."num_integer"."0.1.39"."num_traits"}" deps)
+    ]);
+    features = mkFeatures (features."num_integer"."0.1.39" or {});
+  };
+  features_.num_integer."0.1.39" = deps: f: updateFeatures f (rec {
+    num_integer = fold recursiveUpdate {} [
+      { "0.1.39".default = (f.num_integer."0.1.39".default or true); }
+      { "0.1.39".std =
+        (f.num_integer."0.1.39".std or false) ||
+        (f.num_integer."0.1.39".default or false) ||
+        (num_integer."0.1.39"."default" or false); }
+    ];
+    num_traits = fold recursiveUpdate {} [
+      { "${deps.num_integer."0.1.39".num_traits}"."i128" =
+        (f.num_traits."${deps.num_integer."0.1.39".num_traits}"."i128" or false) ||
+        (num_integer."0.1.39"."i128" or false) ||
+        (f."num_integer"."0.1.39"."i128" or false); }
+      { "${deps.num_integer."0.1.39".num_traits}"."std" =
+        (f.num_traits."${deps.num_integer."0.1.39".num_traits}"."std" or false) ||
+        (num_integer."0.1.39"."std" or false) ||
+        (f."num_integer"."0.1.39"."std" or false); }
+      { "${deps.num_integer."0.1.39".num_traits}".default = (f.num_traits."${deps.num_integer."0.1.39".num_traits}".default or false); }
+    ];
+  }) [
+    (features_.num_traits."${deps."num_integer"."0.1.39"."num_traits"}" deps)
   ];
 
 

--- a/ofborg/src/lib.rs
+++ b/ofborg/src/lib.rs
@@ -24,6 +24,7 @@ extern crate fs2;
 extern crate md5;
 extern crate uuid;
 extern crate env_logger;
+extern crate chrono;
 
 use std::env;
 


### PR DESCRIPTION
This should eventually be replaced with completion times from the builders, but they don't currently provide that information, so local time will have to do.