### PR TITLE
WIP: Git config name and email

### DIFF
--- a/ofborg/test-srcs/make-maintainer-pr.sh
+++ b/ofborg/test-srcs/make-maintainer-pr.sh
@@ -7,6 +7,8 @@ co=$2
 makepr() {
     git init --bare "$bare"
     git clone "$bare" "$co"
+    git -C "$co" config user.email "ofborg-test@example.com"
+    git -C "$co" config user.name "ofborg tests"
 
     cp -r maintainers/* "$co/"
     git -C "$co" add .

--- a/ofborg/test-srcs/make-pr.sh
+++ b/ofborg/test-srcs/make-pr.sh
@@ -7,6 +7,8 @@ co=$2
 makepr() {
     git init --bare "$bare"
     git clone "$bare" "$co"
+    git -C "$co" config user.email "ofborg-test@example.com"
+    git -C "$co" config user.name "ofborg tests"
 
     cp build/* "$co/"
     git -C "$co" add .

--- a/shell.nix
+++ b/shell.nix
@@ -76,6 +76,7 @@ let
     name = "gh-event-forwarder";
     buildInputs = with pkgs; [
       bash
+      nix
       nix-prefetch-git
       rust.rustc
       rust.cargo


### PR DESCRIPTION
git requires an `user.name` and `user.email` to be set for most actions. ofborg shouldn’t depend on the system’s `--global` settings, instead it should provide config options.

This PR is not yet doing that for `clone.rs`:
https://github.com/NixOS/ofborg/blob/released/ofborg/src/clone.rs#L64-L69

