### PR TITLE
nix: pass '--arg nixpkgs' for nixos and generalize argument handling

### DIFF
--- a/ofborg/src/bin/simple-build.rs
+++ b/ofborg/src/bin/simple-build.rs
@@ -5,6 +5,7 @@ extern crate ofborg;
 use std::env;
 
 use ofborg::config;
+use ofborg::nix;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -18,7 +19,7 @@ fn main() {
 
     match nix.safely_build_attrs(
         &Path::new("./"),
-        "./default.nix",
+        nix::File::DefaultNixpkgs,
         vec![String::from("hello")],
     ) {
         Ok(mut out) => {

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -336,7 +336,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         );
         let (can_build, cannot_build) = self.nix.safely_partition_instantiable_attrs(
             refpath.as_ref(),
-            buildfile.clone(),
+            buildfile,
             job.attrs.clone(),
         );
 

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -306,11 +306,11 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         };
 
         let buildfile = match job.subset {
-            Some(commentparser::Subset::NixOS) => "./nixos/release.nix",
-            _ => "./default.nix",
+            Some(commentparser::Subset::NixOS) => nix::File::ReleaseNixOS,
+            _ => nix::File::DefaultNixpkgs,
         };
 
-        if buildfile == "./nixos/release.nix" && self.system == "x86_64-darwin" {
+        if buildfile == nix::File::ReleaseNixOS && self.system == "x86_64-darwin" {
             actions.nasty_hack_linux_only();
             return;
         }
@@ -336,7 +336,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         );
         let (can_build, cannot_build) = self.nix.safely_partition_instantiable_attrs(
             refpath.as_ref(),
-            buildfile,
+            buildfile.clone(),
             job.attrs.clone(),
         );
 


### PR DESCRIPTION
This makes sure nixpkgs isn't passed in using fetchGit or filterSource,
which isn't allowed to be imported with restricted eval.  And avoids
of of the duplication between safely_instantiate_attrs_cmd and
safely_build_attrs_cmd making that easier to test.