### PR TITLE
add cdepillabout to config.extra-known-users.json

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -6,6 +6,7 @@
     "bhipple",
     "bignaux",
     "brainrape",
+    "cdepillabout",
     "costrouc",
     "danieldk",
     "Ekleog",


### PR DESCRIPTION
This is so I can run tests with ofborg.

For instance I'd like to be able to run the tests affected by this PR: https://github.com/NixOS/nixpkgs/pull/54528