### PR TITLE
Maintainer tag

### DIFF
--- a/ofborg/src/tagger.rs
+++ b/ofborg/src/tagger.rs
@@ -247,6 +247,49 @@ impl PathsTagger {
     }
 }
 
+pub struct MaintainerPRTagger {
+    possible: Vec<String>,
+    selected: Vec<String>,
+}
+
+impl Default for MaintainerPRTagger {
+    fn default() -> MaintainerPRTagger {
+        let mut t = MaintainerPRTagger {
+            possible: vec![String::from("11.by: package-maintainer")],
+            selected: vec![],
+        };
+        t.possible.sort();
+
+        t
+    }
+}
+
+impl MaintainerPRTagger {
+    pub fn new() -> MaintainerPRTagger {
+        Default::default()
+    }
+
+    pub fn record_maintainer(&mut self, pr_submitter: &str, identified_maintainers: &[String]) {
+        let mut compare_to: Vec<String> = identified_maintainers.to_vec().clone();
+        compare_to.sort();
+        compare_to.dedup();
+
+        if compare_to.len() == 1 && compare_to.contains(&pr_submitter.to_string()) {
+            self.selected
+                .push(String::from("11.by: package-maintainer"));
+        }
+    }
+
+    pub fn tags_to_add(&self) -> Vec<String> {
+        self.selected.clone()
+    }
+
+    pub fn tags_to_remove(&self) -> Vec<String> {
+        // The cleanup tag is too vague to automatically remove.
+        vec![]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -572,7 +572,8 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                     if let Ok(ref maint) = m {
                         request_reviews(&maint, &pull);
                         let mut maint_tagger = MaintainerPRTagger::new();
-                        maint_tagger.record_maintainer(&issue.user.login, &maint.maintainers());
+                        maint_tagger
+                            .record_maintainer(&issue.user.login, &maint.maintainers_by_package());
                         update_labels(
                             &issue_ref,
                             &maint_tagger.tags_to_add(),

--- a/ofborg/src/tasks/massrebuilder.rs
+++ b/ofborg/src/tasks/massrebuilder.rs
@@ -7,6 +7,7 @@ use crate::maintainers;
 use crate::maintainers::ImpactedMaintainers;
 use amqp::protocol::basic::{BasicProperties, Deliver};
 use hubcaps;
+use hubcaps::issues::Issue;
 use ofborg::acl::ACL;
 use ofborg::checkout;
 use ofborg::commentparser::Subset;
@@ -122,11 +123,11 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
         let gists = self.github.gists();
         let pulls = repo.pulls();
         let pull = pulls.get(job.pr.number);
-        let issue = repo.issue(job.pr.number);
-
+        let issue_ref = repo.issue(job.pr.number);
+        let issue: Issue;
         let auto_schedule_build_archs: Vec<systems::System>;
 
-        match issue.get() {
+        match issue_ref.get() {
             Ok(iss) => {
                 if iss.state == "closed" {
                     self.events.notify(Event::IssueAlreadyClosed);
@@ -142,16 +143,19 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                         &job.repo.full_name,
                     );
                 }
+
+                issue = iss;
             }
+
             Err(e) => {
                 self.events.notify(Event::IssueFetchFailed);
                 info!("Error fetching {}!", job.pr.number);
                 info!("E: {:?}", e);
                 return self.actions().skip(&job);
             }
-        }
+        };
 
-        self.tag_from_title(&issue);
+        self.tag_from_title(&issue_ref);
 
         let mut overall_status = CommitStatus::new(
             repo.statuses(),
@@ -247,7 +251,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
         let changed_paths = co
             .files_changed_from_head(&job.pr.head_sha)
             .unwrap_or_else(|_| vec![]);
-        self.tag_from_paths(&issue, &changed_paths);
+        self.tag_from_paths(&issue_ref, &changed_paths);
 
         overall_status.set_with_description("Merging PR", hubcaps::statuses::State::Pending);
 
@@ -257,11 +261,11 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
 
             info!("Failed to merge {}", job.pr.head_sha);
 
-            update_labels(&issue, &["2.status: merge conflict".to_owned()], &[]);
+            update_labels(&issue_ref, &["2.status: merge conflict".to_owned()], &[]);
 
             return self.actions().skip(&job);
         } else {
-            update_labels(&issue, &[], &["2.status: merge conflict".to_owned()]);
+            update_labels(&issue_ref, &[], &["2.status: merge conflict".to_owned()]);
         }
 
         overall_status
@@ -510,7 +514,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 stdenvtagger.changed(stdenvs.changed());
             }
             update_labels(
-                &issue,
+                &issue_ref,
                 &stdenvtagger.tags_to_add(),
                 &stdenvtagger.tags_to_remove(),
             );
@@ -519,7 +523,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
                 let mut addremovetagger = PkgsAddedRemovedTagger::new();
                 addremovetagger.changed(&removed, &added);
                 update_labels(
-                    &issue,
+                    &issue_ref,
                     &addremovetagger.tags_to_add(),
                     &addremovetagger.tags_to_remove(),
                 );
@@ -580,7 +584,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for MassRebuildWorker<E
             }
 
             update_labels(
-                &issue,
+                &issue_ref,
                 &rebuild_tags.tags_to_add(),
                 &rebuild_tags.tags_to_remove(),
             );


### PR DESCRIPTION
Add the by-maintainer label when the PR is by the maintainer.

~If the PR affects a package with multiple maintainers, it will not be labeled as by the maintainer. (TODO?)~


If the author of the PR is one of any number of maintainers, add the
label. This is in contrast to the previous version, where the submitter
of the PR had to be the ONLY maintainer on ANY package they touched.