### PR TITLE
Fixup tests darwin

### DIFF
--- a/ofborg/src/systems.rs
+++ b/ofborg/src/systems.rs
@@ -17,4 +17,12 @@ impl System {
     pub fn as_build_destination(&self) -> (Option<String>, Option<String>) {
         (None, Some(format!("build-inputs-{}", self.to_string())))
     }
+
+    pub fn can_run_nixos_tests(&self) -> bool {
+        match self {
+            System::X8664Linux => true,
+            System::Aarch64Linux => true,
+            System::X8664Darwin => false,
+        }
+    }
 }

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -101,10 +101,6 @@ impl<'a, 'b> JobActions<'a, 'b> {
         self.tell(worker::Action::Ack);
     }
 
-    pub fn nasty_hack_linux_only(&mut self) {
-        self.tell(worker::Action::Ack);
-    }
-
     pub fn nothing_to_do(&mut self) {
         self.tell(worker::Action::Ack);
     }
@@ -309,11 +305,6 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             Some(commentparser::Subset::NixOS) => nix::File::ReleaseNixOS,
             _ => nix::File::DefaultNixpkgs,
         };
-
-        if buildfile == nix::File::ReleaseNixOS && self.system == "x86_64-darwin" {
-            actions.nasty_hack_linux_only();
-            return;
-        }
 
         let refpath = co.checkout_origin_ref(target_branch.as_ref()).unwrap();
         co.fetch_pr(job.pr.number).unwrap();

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -109,6 +109,15 @@ impl worker::SimpleWorker for GitHubCommentWorker {
             for instruction in instructions {
                 match instruction {
                     commentparser::Instruction::Build(subset, attrs) => {
+                        let build_destinations = match subset {
+                            commentparser::Subset::NixOS => build_destinations
+                                .clone()
+                                .into_iter()
+                                .filter(|x| x.can_run_nixos_tests())
+                                .collect(),
+                            _ => build_destinations.clone(),
+                        };
+
                         let msg = buildjob::BuildJob::new(
                             repo_msg.clone(),
                             pr_msg.clone(),


### PR DESCRIPTION
Since oborg creates "queued" stubs now, we can't send a job for macos only for it to be dropped on the floor later :)