### PR TITLE
add teto to trusted maintainers

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -77,6 +77,7 @@
             "samueldr",
             "shlevy",
             "srhb",
+            "teto",
             "thoughtpolice",
             "timokau",
             "vbgl",


### PR DESCRIPTION
I've been working on kernel and lua infrastructure recently and would like to trigger darwin builds especially without annoying my fellow @7c6f434c  https://github.com/NixOS/nixpkgs/pull/55305