### PR TITLE
known-users: add anton-latukha

### DIFF
--- a/config.known-users.json
+++ b/config.known-users.json
@@ -10,6 +10,7 @@
       "aminechikhaoui",
       "andersontorres",
       "andir",
+      "anton-latukha",
       "arianvp",
       "aristidb",
       "armijnhemel",


### PR DESCRIPTION
Good day.

I maintain a couple of packages for now, also contributed changes to different packages/sections so far.

All changes I send - I properly prepare - do sandboxed builds, run and test binaries, determine clojure sizes, and run test locally.

It was suggested to me to add myself to the list, by maintainer in some of my summer PRs (can't find now).

And now also found that I probably should ([1](https://github.com/NixOS/nixpkgs/pull/56256), [2](https://github.com/NixOS/nixpkgs/pull/56047)) - to save main maintainers one step, a switch and a time, and ask borg to run the appropriate unit tests myself. And core maintainer would show up at the PR - and borg already shows successful Nix unit test results.

Thank you, also for creation of ofborg.