### PR TITLE
extra-known-users: add myself (delroth)

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -9,6 +9,7 @@
     "cdepillabout",
     "costrouc",
     "danieldk",
+    "delroth",
     "Ekleog",
     "ElvishJerricco",
     "Enzime",


### PR DESCRIPTION
As suggested on NixOS/nixpkgs#56554. I maintain a few packages and sometimes help with version bumps when I noticed packages lagging behind. Being able to trigger ofborg builds/test runs would save a few review roundtrips.