### PR TITLE
config.extra-known-users.json: Add myself (balsoft)

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -3,6 +3,7 @@
     "anton-latukha",
     "akru",
     "arianvp",
+    "balsoft",
     "bbarker",
     "bhipple",
     "bignaux",


### PR DESCRIPTION
Adds "balsoft" to the list of extra known users.