### PR TITLE
outpaths.nix: Makes callable

### DIFF
--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -1,7 +1,12 @@
-{ checkMeta }:
+#!/usr/bin/env nix-shell
+# When using as a callable script, passing `--argstr path some/path` overrides $PWD.
+#!nix-shell -p nix -i "nix-env -qaP --no-name --out-path --arg checkMeta true --argstr path $PWD -f"
+{ checkMeta
+, path ? ./.
+}:
 let
-  lib = import ./lib;
-  hydraJobs = import ./pkgs/top-level/release.nix
+  lib = import (path + "/lib");
+  hydraJobs = import (path + "/pkgs/top-level/release.nix")
     # Compromise: accuracy vs. resources needed for evaluation.
     {
       supportedSystems = [


### PR DESCRIPTION
The behaviour of the callable outpaths.nix is such that it will call
nix-env as expected to run the equivalent ofborg step, in the CWD.

The directory it is ran on can be changed using `--argstr path ...`.