### PR TITLE
nixpkgs: Tests nixos' `tested` job

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -399,6 +399,19 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 self.nix.clone(),
             ),
             EvalChecker::new(
+                "nixos",
+                nix::Operation::Instantiate,
+                vec![
+                    String::from("--arg"),
+                    String::from("nixpkgs"),
+                    String::from("{ outPath=./.; revCount=999999; shortRev=\"ofborg\"; }"),
+                    String::from("./nixos/release-combined.nix"),
+                    String::from("-A"),
+                    String::from("tested"),
+                ],
+                self.nix.clone(),
+            ),
+            EvalChecker::new(
                 "nixos-options",
                 nix::Operation::Instantiate,
                 vec![


### PR DESCRIPTION
This, I hope, will ensure we don't have the `tested` job vanish for a couple days again in the future.

* * *

This was not tested, but (1) this is the same structure of the other nixos tests with a different arg and (2) this equivalent instantiation works.

```
nix-instantiate --arg nixpkgs '{ outPath=./.; revCount=999999; shortRev="ofborg"; }' nixos/release-combined.nix -A tested
```

The name of the check is `nixos` as the equivalent for Darwin is simply named `darwin`.