### PR TITLE
extra-known-users: Add schmittlauch

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -46,6 +46,7 @@
     "pSub",
     "rvolosatovs",
     "samueldr",
+    "schmittlauch",
     "Synthetica9",
     "smaret",
     "tadfisher",


### PR DESCRIPTION
As requested by @Mic92 in NixOS/nixpkgs#60408 I am adding myself as a trusted user, so that OfBorg can automatically build on more platforms when testing my PRs.