### PR TITLE
extra-known-users: Add jonringer

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -34,6 +34,7 @@
     "jluttine",
     "johanot",
     "johnazoidberg",
+    "jonringer",
     "kalbasit",
     "knedlsepp",
     "lilyball",

--- a/config.known-users.json
+++ b/config.known-users.json
@@ -89,6 +89,7 @@
       "joachifm",
       "johanot",
       "jokogr",
+      "jonringer",
       "jtojnar",
       "jwiegley",
       "kalbasit",


### PR DESCRIPTION
Was asked to add myself. https://github.com/NixOS/nixpkgs/pull/63483#issuecomment-503452036

Anything to help with the PR process :)

I'm not actually sure what the difference between config.{,extra-}known-users is. But looking at the pull request history, individuals seem to add themselves to both, so I'm just following suit.

If I added myself to the wrong lists, let me know.