### PR TITLE
extra-known-users: Add xrelkd

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -64,6 +64,7 @@
     "volth",
     "woffs",
     "xeji",
+    "xrelkd",
     "yesbox",
     "yorickvP",
     "yurrriq"


### PR DESCRIPTION
As requested by @marsam in NixOS/nixpkgs#63220 I am adding myself as a trusted user, so that I can more easily review PRs.