### PR TITLE
FUNDING: use the shared .github FUNDING yaml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-patreon: ofborg


### PR DESCRIPTION
The funding is now configured in NixOS/.github/FUNDING.yml