### PR TITLE
maintainers: compare maintainer usernames in lowercase

### DIFF
--- a/ofborg/src/maintainers.nix
+++ b/ofborg/src/maintainers.nix
@@ -77,7 +77,7 @@ let
     (builtins.map
       (pkg:
         builtins.map (maintainer: {
-          handle = maintainer.github;
+          handle = pkgs.lib.toLower maintainer.github;
           packageName = pkg.name;
           dueToFiles = pkg.filenames;
         })

--- a/ofborg/src/maintainers.rs
+++ b/ofborg/src/maintainers.rs
@@ -12,7 +12,7 @@ pub struct MaintainersByPackage(pub HashMap<Package, HashSet<Maintainer>>);
 pub struct Maintainer(String);
 impl<'a> From<&'a str> for Maintainer {
     fn from(name: &'a str) -> Maintainer {
-        Maintainer(name.to_owned())
+        Maintainer(name.to_ascii_lowercase().to_owned())
     }
 }
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]


### PR DESCRIPTION
At least a few maintainers in `<nixpkgs>/maintainers/maintainer-list.nix`
specified a lowercase username for GitHub while actually having a
username with upper case characters.
Ofborg performs case-sensitive comparisons on PR submitters and the
above mentioned usernames. This causes borg to not recognize users when
there is different casing between the above list and the 'user.name'
value of github's api response, even though the casing is irrelevant for
distinguishing different users.

Please note that I don't know how to really test if this works as expected and would appreciate input on how to do that or how to improve my change :)
I did however build ofborg.{php,rs} and executed the `checkPhase` from shell.nix.