### PR TITLE
extra-known-users: Add devhell

### DIFF
--- a/config.extra-known-users.json
+++ b/config.extra-known-users.json
@@ -12,6 +12,7 @@
     "costrouc",
     "danieldk",
     "delroth",
+    "devhell",
     "Ekleog",
     "ElvishJerricco",
     "Enzime",


### PR DESCRIPTION
Now that I've been made a member, it's probably best to be able to
trigger ofBorg where appropriate and necessary.