### PR TITLE
config.public.json: add myself to trusted_users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -24,6 +24,7 @@
             "aszlig",
             "basvandijk",
             "c0bw3b",
+            "cdepillabout",
             "cleverca22",
             "copumpkin",
             "coreyoconnor",


### PR DESCRIPTION
I sometimes fix issues for darwin with Haskell stuff in nixpkgs, so it would be nice to be able to run builds on darwin with ofborg as a double check.

Here's an example of a build I would like to run on darwin:

https://github.com/NixOS/nixpkgs/pull/73434

I recently got commit rights to nixpkgs, so hopefully that counts for me being trusted:

https://github.com/NixOS/nixpkgs-committers/issues/60#issuecomment-546211514