### PR TITLE
add @Kiwi to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -55,6 +55,7 @@
             "jonringer",
             "jtojnar",
             "kalbasit",
+            "kiwi",
             "knedlsepp",
             "lassulus",
             "lheckemann",


### PR DESCRIPTION
I'm trying to get more active contributing to nixpkgs so making myself known to ofborg seems like a good idea and also I'd like to add support for macOS to a few packages I already maintain sometime real soon (tm) so trusted users it is.

I'm like really trustworthy, I've had access to the community aarch64 server for months and only broke it once! Just look at my face :smirk: (jk, I haven't broken it... yet) Oh, and also @grahamc said to, so there's that. :smile: 