### PR TITLE
Update to current nixpkgs-unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nix {} }:
+{ pkgs ? import ./nix { overlays = [ (import ./nix/overlay.nix) ]; } }:
 
 let
   ofborgOverrides = {

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "201d739b0ffbebceb444864d1856babcd1a666a8",
-  "date": "2018-12-30T01:29:37+00:00",
-  "sha256": "0mfkzmylglpw84w85zs3djpspcx45bg3s62hk4j44dxl2p0fvggj",
+  "rev": "e2b4abe3c8f2e09adfc6a52007841d1b96c89371",
+  "date": "2020-02-19T01:57:21+01:00",
+  "sha256": "1l3jfr74s7wmx3fk5y76ayazbfclvnr532kg1hypbzydp3n372rz",
   "fetchSubmodules": false
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,12 @@
+(self: super: {
+  defaultCrateOverrides = super.defaultCrateOverrides // {
+    openssl-sys = attrs: {
+      buildInputs = [ self.openssl_1_0_2 ];
+      nativeBuildInputs = [ self.pkgconfig ];
+    };
+    openssl = attrs: {
+      DEP_OPENSSL_VERSION = "102";
+    };
+  };
+})
+

--- a/ofborg/build.rs
+++ b/ofborg/build.rs
@@ -11,46 +11,46 @@ enum MetricType {
 impl MetricType {
     fn collector_type(&self) -> String {
         match self {
-            &MetricType::Ticker(_) => String::from("u64"),
-            &MetricType::Counter(_) => String::from("u64"),
+            MetricType::Ticker(_) => String::from("u64"),
+            MetricType::Counter(_) => String::from("u64"),
         }
     }
 
     fn enum_matcher_types(&self) -> String {
         let fields = self.enum_field_types();
 
-        if fields.len() > 0 {
+        if !fields.is_empty() {
             format!("{}({})", self.variant(), fields.join(", "))
         } else {
-            format!("{}", self.variant())
+            self.variant()
         }
     }
 
     fn variant(&self) -> String {
         match self {
-            &MetricType::Ticker(ref event) => event.variant.clone(),
-            &MetricType::Counter(ref event) => event.variant.clone(),
+            MetricType::Ticker(ref event) => event.variant.clone(),
+            MetricType::Counter(ref event) => event.variant.clone(),
         }
     }
 
     fn metric_type(&self) -> String {
         match self {
-            &MetricType::Ticker(_) => String::from("counter"),
-            &MetricType::Counter(_) => String::from("counter"),
+            MetricType::Ticker(_) => String::from("counter"),
+            MetricType::Counter(_) => String::from("counter"),
         }
     }
 
     fn metric_name(&self) -> String {
         match self {
-            &MetricType::Ticker(ref event) => event.metric_name.clone(),
-            &MetricType::Counter(ref event) => event.metric_name.clone(),
+            MetricType::Ticker(ref event) => event.metric_name.clone(),
+            MetricType::Counter(ref event) => event.metric_name.clone(),
         }
     }
 
     fn description(&self) -> String {
         match self {
-            &MetricType::Ticker(ref event) => event.description.clone(),
-            &MetricType::Counter(ref event) => event.description.clone(),
+            MetricType::Ticker(ref event) => event.description.clone(),
+            MetricType::Counter(ref event) => event.description.clone(),
         }
     }
 
@@ -58,10 +58,10 @@ impl MetricType {
         let event: &Metric;
 
         match self {
-            &MetricType::Ticker(ref i_event) => {
+            MetricType::Ticker(ref i_event) => {
                 event = i_event;
             }
-            &MetricType::Counter(ref i_event) => {
+            MetricType::Counter(ref i_event) => {
                 event = i_event;
             }
         }
@@ -72,15 +72,15 @@ impl MetricType {
             .map(|&(ref _fieldname, ref fieldtype)| fieldtype.clone())
             .collect();
 
-        return fields;
+        fields
     }
 
     fn enum_field_types(&self) -> Vec<String> {
         let mut extra_fields: Vec<String> = vec![];
 
         match self {
-            &MetricType::Ticker(_) => {}
-            &MetricType::Counter(_) => {
+            MetricType::Ticker(_) => {}
+            MetricType::Counter(_) => {
                 extra_fields = vec![self.collector_type()];
             }
         }
@@ -88,17 +88,17 @@ impl MetricType {
         let mut fields: Vec<String> = self.enum_index_types();
         fields.append(&mut extra_fields);
 
-        return fields;
+        fields
     }
 
     fn enum_index_names(&self) -> Vec<String> {
         let event: &Metric;
 
         match self {
-            &MetricType::Ticker(ref i_event) => {
+            MetricType::Ticker(ref i_event) => {
                 event = i_event;
             }
-            &MetricType::Counter(ref i_event) => {
+            MetricType::Counter(ref i_event) => {
                 event = i_event;
             }
         }
@@ -109,15 +109,15 @@ impl MetricType {
             .map(|&(ref fieldname, ref _fieldtype)| fieldname.clone())
             .collect();
 
-        return fields;
+        fields
     }
 
     fn enum_field_names(&self) -> Vec<String> {
         let mut extra_fields: Vec<String> = vec![];
 
         match self {
-            &MetricType::Ticker(_) => {}
-            &MetricType::Counter(_) => {
+            MetricType::Ticker(_) => {}
+            MetricType::Counter(_) => {
                 extra_fields = vec!["value".to_owned()];
             }
         }
@@ -125,13 +125,13 @@ impl MetricType {
         let mut fields: Vec<String> = self.enum_index_names();
         fields.append(&mut extra_fields);
 
-        return fields;
+        fields
     }
 
     fn record_value(&self) -> String {
         match self {
-            &MetricType::Ticker(_) => String::from("1"),
-            &MetricType::Counter(_) => String::from("value"),
+            MetricType::Ticker(_) => String::from("1"),
+            MetricType::Counter(_) => String::from("value"),
         }
     }
 }
@@ -147,18 +147,18 @@ fn name_to_parts(name: &str) -> Vec<String> {
     let mut parts: Vec<String> = vec![];
     let mut buf = String::from("");
     for c in name.chars() {
-        if char::is_uppercase(c) && buf.len() > 0 {
+        if char::is_uppercase(c) && !buf.is_empty() {
             parts.push(buf.to_owned());
             buf = String::from("");
         }
         buf.push_str(&c.to_string());
     }
-    if buf.len() > 0 {
+    if !buf.is_empty() {
         parts.push(buf.to_owned());
         std::mem::drop(buf);
     }
 
-    return parts;
+    parts
 }
 
 impl Metric {
@@ -166,13 +166,11 @@ impl Metric {
         let parts = name_to_parts(name);
 
         MetricType::Ticker(Metric {
-            variant: parts.iter().map(|f| f.clone().to_owned()).collect(),
+            variant: parts.iter().cloned().collect(),
             fields: fields
-                .unwrap_or(vec![])
+                .unwrap_or_else(|| vec![])
                 .iter()
-                .map(|&(ref fieldname, ref fieldtype)| {
-                    (fieldname.clone().to_owned(), fieldtype.clone().to_owned())
-                })
+                .map(|(fieldname, fieldtype)| ((*fieldname).to_string(), (*fieldtype).to_string()))
                 .collect(),
             metric_name: parts.join("_").to_lowercase(),
             description: desc.to_owned(),
@@ -183,13 +181,11 @@ impl Metric {
         let parts = name_to_parts(name);
 
         MetricType::Counter(Metric {
-            variant: parts.iter().map(|f| f.clone().to_owned()).collect(),
+            variant: parts.iter().cloned().collect(),
             fields: fields
-                .unwrap_or(vec![])
+                .unwrap_or_else(|| vec![])
                 .iter()
-                .map(|&(ref fieldname, ref fieldtype)| {
-                    (fieldname.clone().to_owned(), fieldtype.clone().to_owned())
-                })
+                .map(|(fieldname, fieldtype)| ((*fieldname).to_string(), (*fieldtype).to_string()))
                 .collect(),
             metric_name: parts.join("_").to_lowercase(),
             description: desc.to_owned(),
@@ -391,7 +387,7 @@ pub enum Event {
         .collect();
 
     f.write_all(variants.join(",\n").as_bytes()).unwrap();
-    f.write_all("\n}\n\n".as_bytes()).unwrap();
+    f.write_all(b"\n}\n\n").unwrap();
 
     f.write_all(
         b"pub fn event_metric_name(event: &Event) -> String {
@@ -409,12 +405,11 @@ pub enum Event {
                 .map(|_| String::from("_"))
                 .collect();
 
-            let variant_match: String;
-            if fields.len() > 0 {
-                variant_match = format!("{}({})", &mtype.variant(), fields.join(", "));
+            let variant_match = if !fields.is_empty() {
+                format!("{}({})", &mtype.variant(), fields.join(", "))
             } else {
-                variant_match = format!("{}", &mtype.variant());
-            }
+                mtype.variant()
+            };
 
             format!(
                 "    Event::{} => String::from(\"{}\")",
@@ -425,12 +420,12 @@ pub enum Event {
         .collect();
 
     f.write_all(variants.join(",\n").as_bytes()).unwrap();
-    f.write_all("}\n  }".as_bytes()).unwrap();
+    f.write_all(b"}\n  }").unwrap();
 
     // Create a struct to hold all the possible metrics
     f.write_all(
         b"
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub struct MetricCollector {
 ",
     )
@@ -441,18 +436,26 @@ pub struct MetricCollector {
         .map(|mtype| {
             let mut fields: Vec<String> = mtype.enum_index_types();
             fields.push("String".to_owned()); // Instance
+            let fields_str = {
+                let s = fields.join(", ");
+                if fields.len() > 1 {
+                    format!("({})", s)
+                } else {
+                    s
+                }
+            };
 
             format!(
-                "  {}: Arc<Mutex<HashMap<({}),{}>>>",
+                "  {}: Arc<Mutex<HashMap<{},{}>>>",
                 mtype.metric_name(),
-                fields.join(", "),
+                fields_str,
                 mtype.collector_type(),
             )
         })
         .collect();
 
     f.write_all(variants.join(",\n").as_bytes()).unwrap();
-    f.write_all("\n}\n\n".as_bytes()).unwrap();
+    f.write_all(b"\n}\n\n").unwrap();
 
     // Create a struct to hold all the possible metrics
     f.write_all(
@@ -474,10 +477,10 @@ impl MetricCollector {
         .map(|mtype| {
             let fields: Vec<String> = mtype.enum_field_names();
 
-            let variant_match = if fields.len() > 0 {
+            let variant_match = if !fields.is_empty() {
                 format!("{}({})", &mtype.variant(), fields.join(", "))
             } else {
-                format!("{}", &mtype.variant())
+                mtype.variant()
             };
 
             let mut index_names: Vec<String> = mtype.enum_index_names();
@@ -510,8 +513,8 @@ impl MetricCollector {
         .collect();
 
     f.write_all(variants.join(",\n").as_bytes()).unwrap();
-    f.write_all("\n    }\n".as_bytes()).unwrap();
-    f.write_all("\n  }\n".as_bytes()).unwrap();
+    f.write_all(b"\n    }\n").unwrap();
+    f.write_all(b"\n  }\n").unwrap();
 
     f.write_all(
         b"pub fn prometheus_output(&self) -> String {
@@ -525,15 +528,13 @@ impl MetricCollector {
         .map(|mtype| {
             let mut index_fields: Vec<String> = mtype.enum_index_names();
             index_fields.push("instance".to_owned());
-            let ref_index_fields: Vec<String> =
-                index_fields.iter().map(|m| format!("{}", m)).collect();
+            let ref_index_fields: Vec<String> = index_fields.clone();
 
-            let for_matcher: String;
-            if index_fields.len() > 1 {
-                for_matcher = format!("({})", ref_index_fields.join(", "));
+            let for_matcher = if index_fields.len() > 1 {
+                format!("({})", ref_index_fields.join(", "))
             } else {
-                for_matcher = ref_index_fields.join(", ");
-            }
+                ref_index_fields.join(", ")
+            };
 
             let key_value_pairs: Vec<String> = index_fields
                 .iter()
@@ -572,6 +573,6 @@ impl MetricCollector {
         .collect();
 
     f.write_all(variants.join("\n").as_bytes()).unwrap();
-    f.write_all("output\n  }".as_bytes()).unwrap();
-    f.write_all("\n}".as_bytes()).unwrap();
+    f.write_all(b"output\n  }").unwrap();
+    f.write_all(b"\n}").unwrap();
 }

--- a/ofborg/src/asynccmd.rs
+++ b/ofborg/src/asynccmd.rs
@@ -28,7 +28,7 @@ pub struct AsyncCmd {
 }
 
 pub struct SpawnedAsyncCmd {
-    waiter: JoinHandle<(Option<Result<ExitStatus, io::Error>>)>,
+    waiter: JoinHandle<Option<Result<ExitStatus, io::Error>>>,
     rx: Receiver<String>,
 }
 
@@ -121,13 +121,13 @@ impl AsyncCmd {
             spawn_join(
                 WaitTarget::Stdout,
                 monitor_tx.clone(),
-                reader_tx(child.stdout.take().unwrap(), proc_tx.clone()),
+                reader_tx(child.stdout.take().unwrap(), proc_tx),
             ),
         );
 
         waiters.insert(
             WaitTarget::Child,
-            child_wait(WaitTarget::Child, monitor_tx.clone(), child),
+            child_wait(WaitTarget::Child, monitor_tx, child),
         );
 
         let head_waiter = thread::spawn(move || {

--- a/ofborg/src/bin/build-faker.rs
+++ b/ofborg/src/bin/build-faker.rs
@@ -44,8 +44,8 @@ fn main() {
     let logbackrk = "NixOS/ofborg.42".to_owned();
 
     let msg = buildjob::BuildJob {
-        repo: repo_msg.clone(),
-        pr: pr_msg.clone(),
+        repo: repo_msg,
+        pr: pr_msg,
         subset: Some(commentparser::Subset::Nixpkgs),
         attrs: vec!["success".to_owned()],
         logs: Some((Some("logs".to_owned()), Some(logbackrk.to_lowercase()))),

--- a/ofborg/src/checkout.rs
+++ b/ofborg/src/checkout.rs
@@ -58,8 +58,8 @@ impl CachedProject {
         Ok(CachedProjectCo {
             root: new_root,
             id,
-            clone_url: self.clone_from().clone(),
-            local_reference: self.clone_to().clone(),
+            clone_url: self.clone_from(),
+            local_reference: self.clone_to(),
         })
     }
 

--- a/ofborg/src/easyamqp.rs
+++ b/ofborg/src/easyamqp.rs
@@ -308,7 +308,7 @@ pub fn session_from_config(config: &RabbitMQConfig) -> Result<amqp::Session, amq
         ..amqp::Options::default()
     };
 
-    let session = try!(amqp::Session::new(options));
+    let session = amqp::Session::new(options)?;
 
     info!("Connected to {}", &config.host);
     Ok(session)

--- a/ofborg/src/maintainers.rs
+++ b/ofborg/src/maintainers.rs
@@ -12,7 +12,7 @@ pub struct MaintainersByPackage(pub HashMap<Package, HashSet<Maintainer>>);
 pub struct Maintainer(String);
 impl<'a> From<&'a str> for Maintainer {
     fn from(name: &'a str) -> Maintainer {
-        Maintainer(name.to_ascii_lowercase().to_owned())
+        Maintainer(name.to_ascii_lowercase())
     }
 }
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash)]

--- a/ofborg/src/message/buildresult.rs
+++ b/ofborg/src/message/buildresult.rs
@@ -162,7 +162,12 @@ mod tests {
         let result: BuildResult = serde_json::from_str(input).expect("result required");
         assert_eq!(result.status(), BuildStatus::Success);
         let output = serde_json::to_string(&result).expect("json required");
-        assert_eq!(output, r#"{"tag":"V1","repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","status":"Success","skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#, "json of: {:?}", result);
+        assert_eq!(
+            output,
+            r#"{"tag":"V1","repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","status":"Success","skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#,
+            "json of: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -171,7 +176,12 @@ mod tests {
         let result: BuildResult = serde_json::from_str(input).expect("result required");
         assert_eq!(result.status(), BuildStatus::Success);
         let output = serde_json::to_string(&result).expect("json required");
-        assert_eq!(output, r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":true,"status":"Success","skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#, "json of: {:?}", result);
+        assert_eq!(
+            output,
+            r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":true,"status":"Success","skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#,
+            "json of: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -180,7 +190,12 @@ mod tests {
         let result: BuildResult = serde_json::from_str(input).expect("result required");
         assert_eq!(result.status(), BuildStatus::Skipped);
         let output = serde_json::to_string(&result).expect("json required");
-        assert_eq!(output, r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":[],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":null,"status":null,"skipped_attrs":null,"attempted_attrs":null}"#, "json of: {:?}", result);
+        assert_eq!(
+            output,
+            r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":[],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":null,"status":null,"skipped_attrs":null,"attempted_attrs":null}"#,
+            "json of: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -189,6 +204,11 @@ mod tests {
         let result: BuildResult = serde_json::from_str(input).expect("result required");
         assert_eq!(result.status(), BuildStatus::Success);
         let output = serde_json::to_string(&result).expect("json required");
-        assert_eq!(output, r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":true,"status":null,"skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#, "json of: {:?}", result);
+        assert_eq!(
+            output,
+            r#"{"repo":{"owner":"NixOS","name":"nixpkgs","full_name":"NixOS/nixpkgs","clone_url":"https://github.com/nixos/nixpkgs.git"},"pr":{"target_branch":"master","number":42,"head_sha":"0000000000000000000000000000000000000000"},"system":"x86_64-linux","output":["unpacking sources"],"attempt_id":"attempt-id-foo","request_id":"bogus-request-id","success":true,"status":null,"skipped_attrs":["AAAAAASomeThingsFailToEvaluate"],"attempted_attrs":["hello"]}"#,
+            "json of: {:?}",
+            result
+        );
     }
 }

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -147,8 +147,8 @@ impl Nix {
             .into_iter()
             .map(
                 |attr| match self.safely_instantiate_attrs(nixpkgs, file, vec![attr.clone()]) {
-                    Ok(_) => Ok(attr.clone()),
-                    Err(f) => Err((attr.clone(), lines_from_file(f))),
+                    Ok(_) => Ok(attr),
+                    Err(f) => Err((attr, lines_from_file(f))),
                 },
             )
             .collect();

--- a/ofborg/src/nixstats.rs
+++ b/ofborg/src/nixstats.rs
@@ -116,31 +116,23 @@ impl<'a> EvaluationStatsDiff<'a> {
             diff: String,
             diff_pct: String,
         }
+
         impl Row {
             fn from_u64(left: u64, right: u64) -> Row {
-                let diff: u64;
-                let direction: &str;
-                let diff_pct: String;
+                let (diff, direction): (u64, _) = match left.cmp(&right) {
+                    std::cmp::Ordering::Greater => (left - right, "↘ "),
+                    std::cmp::Ordering::Less => (right - left, "↗ "),
+                    std::cmp::Ordering::Equal => (0, ""),
+                };
 
-                if left > right {
-                    diff = left - right;
-                    direction = "↘ ";
-                } else if left < right {
-                    diff = right - left;
-                    direction = "↗ ";
-                } else {
-                    diff = 0;
-                    direction = "";
-                }
-
-                if diff > 0 {
-                    diff_pct = format!(
+                let diff_pct: String = if diff > 0 {
+                    format!(
                         "{:.2}%",
                         ((right as f64) - (left as f64)) / (left as f64) * 100.0
-                    );
+                    )
                 } else {
-                    diff_pct = String::from("");
-                }
+                    String::from("")
+                };
 
                 Row {
                     before: left.separated_string(),
@@ -151,29 +143,23 @@ impl<'a> EvaluationStatsDiff<'a> {
             }
 
             fn from_f32(left: f32, right: f32) -> Row {
-                let diff: f32;
-                let direction: &str;
-                let diff_pct: String;
+                let (diff, direction): (f32, _) = match left
+                    .partial_cmp(&right)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                {
+                    std::cmp::Ordering::Greater => (left - right, "↘ "),
+                    std::cmp::Ordering::Less => (right - left, "↗ "),
+                    std::cmp::Ordering::Equal => (0 as f32, ""),
+                };
 
-                if left > right {
-                    diff = left - right;
-                    direction = "↘ ";
-                } else if left < right {
-                    diff = right - left;
-                    direction = "↗ ";
-                } else {
-                    diff = 0.0;
-                    direction = "";
-                }
-
-                if diff > 0.0 {
-                    diff_pct = format!(
+                let diff_pct: String = if diff > 0 as _ {
+                    format!(
                         "{:.2}%",
-                        (f64::from(right) - f64::from(left)) / f64::from(left) * 100.0
-                    );
+                        ((right as f64) - (left as f64)) / (left as f64) * 100.0
+                    )
                 } else {
-                    diff_pct = String::from("");
-                }
+                    String::from("")
+                };
 
                 Row {
                     before: format!("{:.2}", left),

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -216,7 +216,7 @@ impl<'a> NixpkgsStrategy<'a> {
                     self.record_impacted_maintainers(&dir, &attrs);
                 }
 
-                rebuild_tags.parse_attrs(attrs.clone());
+                rebuild_tags.parse_attrs(attrs);
             }
 
             update_labels(

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -229,7 +229,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for EvaluationWorker<E>
             target_branch_rebuild_sniff_start.elapsed().as_secs(),
         ));
         self.events
-            .notify(Event::EvaluationDurationCount(target_branch.clone()));
+            .notify(Event::EvaluationDurationCount(target_branch));
 
         overall_status.set_with_description("Fetching PR", hubcaps::statuses::State::Pending);
 

--- a/ofborg/src/tasks/evaluationfilter.rs
+++ b/ofborg/src/tasks/evaluationfilter.rs
@@ -93,8 +93,8 @@ impl worker::SimpleWorker for EvaluationFilterWorker {
         };
 
         let msg = evaluationjob::EvaluationJob {
-            repo: repo_msg.clone(),
-            pr: pr_msg.clone(),
+            repo: repo_msg,
+            pr: pr_msg,
         };
 
         return vec![

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -101,7 +101,7 @@ impl worker::SimpleWorker for GitHubCommentWorker {
         let pr_msg = Pr {
             number: job.issue.number,
             head_sha: pr.head.sha.clone(),
-            target_branch: Some(pr.base.commit_ref.clone()),
+            target_branch: Some(pr.base.commit_ref),
         };
 
         let mut response: Vec<worker::Action> = vec![];

--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -196,7 +196,7 @@ impl worker::SimpleWorker for LogMessageCollector {
             } else {
                 let decode_msg: Result<BuildResult, _> = serde_json::from_slice(body);
                 if let Ok(msg) = decode_msg {
-                    attempt_id = msg.legacy().attempt_id.clone();
+                    attempt_id = msg.legacy().attempt_id;
                     message = MsgType::Finish(Box::new(msg));
                 } else {
                     return Err(format!("failed to decode job: {:?}", decode_msg));

--- a/php/default.nix
+++ b/php/default.nix
@@ -4,7 +4,8 @@
 
 let
   composerEnv = import ./composer-env.nix {
-    inherit (pkgs) stdenv writeTextFile fetchurl php unzip;
+    inherit (pkgs) stdenv writeTextFile fetchurl unzip;
+    php = pkgs.php72;
   };
 in
 import ./php-packages.nix {

--- a/release.nix
+++ b/release.nix
@@ -15,7 +15,12 @@ let
     (collector: system:
       collector // {
         "${system}" = import ./. {
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              (import ./nix/overlay.nix)
+            ];
+          };
         };
       }
     )

--- a/shell.nix
+++ b/shell.nix
@@ -41,7 +41,7 @@ let
       latest.rustChannels.stable.rust
       git
       pkgconfig
-      openssl.dev
+      openssl_1_0_2.dev
     ]
       ++ stdenv.lib.optional stdenv.isDarwin pkgs.darwin.Security;
 
@@ -80,7 +80,7 @@ let
       latest.rustChannels.stable.rust
       #rustfmt
       #carnix
-      openssl.dev
+      openssl_1_0_2.dev
       pkgconfig
       git
     ]


### PR DESCRIPTION
This required the introduction of an overlay file since ofBorg still
requires openssl 1.0.2. Updating to newer version of openssl also
requires updating the amqp library which requires some more involved
changes.

The php code is only updated to php 7.2 and not 7.3 (the default in
nixpkgs) since there seem to been a few syntax changes that aren't yet
compatible with composer2nix.


In previous versions of the rust infrastructure within nixpkgs we would
have been able to override all crates during the invocation of the
target crate. That `override` feature was removed as it caused a huge
eval overhead for larger projects. We did end up with (n^2)
instantiations of dependencies since they were being overridden on every
invocation of every dependency on every level further down the chain.
The current understanding is that the build tooling that each project is
using (e.g.  crate2nix, crate2nix, …) that is driving the actual build
could easily reintroduce that feature without the overhead.