### PR TITLE
Add check for lib tests

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -426,6 +426,17 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 self.nix.clone(),
             ),
             EvalChecker::new(
+                "lib-tests",
+                nix::Operation::Build,
+                vec![
+                    String::from("--arg"),
+                    String::from("pkgs"),
+                    String::from("import ./. {}"),
+                    String::from("./lib/tests/release.nix"),
+                ],
+                self.nix.clone(),
+            ),
+            EvalChecker::new(
                 "nixos",
                 nix::Operation::Instantiate,
                 vec![


### PR DESCRIPTION
Without this, a big part of the lib tests aren't being done, which
previously lead to e.g. https://github.com/NixOS/nixpkgs/pull/76861
And this will also be useful for checked maintainers in https://github.com/NixOS/nixpkgs/pull/82461

I have not tested this code in any way