### PR TITLE
checkout: silence diffs when checking validity of a commit

### DIFF
--- a/ofborg/src/checkout.rs
+++ b/ofborg/src/checkout.rs
@@ -117,6 +117,7 @@ impl CachedProjectCo {
         let result = Command::new("git")
             .arg("--no-pager")
             .arg("show")
+            .arg("--no-patch")
             .arg(commit)
             .current_dir(self.clone_to())
             .status()


### PR DESCRIPTION
Otherwise, when people submit treewide PRs to nixpkgs, the logs get
cluttered with thousands of useless diffs.

---

The current solution still displays the commit info (e.g. hash, author, date, message, etc); an alternative solution would be to send stdout to `/dev/null` by using `.stdout(Stdio::null())`.

This is the only command we spawn that (I think) could possibly generate a diff; if it's still a problem, I'll look into it again.