### PR TITLE
Logging cleanup

### DIFF
--- a/ofborg/src/bin/build-faker.rs
+++ b/ofborg/src/bin/build-faker.rs
@@ -1,3 +1,4 @@
+use log::{info, log};
 use ofborg::commentparser;
 use ofborg::config;
 use ofborg::easyamqp;
@@ -11,10 +12,10 @@ fn main() {
     let cfg = config::load(env::args().nth(1).unwrap().as_ref());
     ofborg::setup_log();
 
-    println!("Hello, world!");
+    info!("Hello, world!");
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let mut channel = session.open_channel(1).unwrap();
 
@@ -56,7 +57,7 @@ fn main() {
     }
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/builder.rs
+++ b/ofborg/src/bin/builder.rs
@@ -1,5 +1,5 @@
 use amqp::Basic;
-use log::{log, warn};
+use log::{info, log, warn};
 use ofborg::checkout;
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
@@ -103,10 +103,10 @@ fn main() {
         )
         .unwrap();
 
-    println!("Fetching jobs from {}", &queue_name);
+    info!("Fetching jobs from {}", &queue_name);
     channel.start_consuming();
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/evaluation-filter.rs
+++ b/ofborg/src/bin/evaluation-filter.rs
@@ -1,4 +1,5 @@
 use amqp::Basic;
+use log::{info, log};
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
 use ofborg::tasks;
@@ -10,10 +11,10 @@ fn main() {
     let cfg = config::load(env::args().nth(1).unwrap().as_ref());
     ofborg::setup_log();
 
-    println!("Hello, world!");
+    info!("Hello, world!");
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let mut channel = session.open_channel(1).unwrap();
 
@@ -84,10 +85,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/github-comment-filter.rs
+++ b/ofborg/src/bin/github-comment-filter.rs
@@ -1,4 +1,5 @@
 use amqp::Basic;
+use log::{info, log};
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
 use ofborg::tasks;
@@ -10,10 +11,10 @@ fn main() {
     let cfg = config::load(env::args().nth(1).unwrap().as_ref());
     ofborg::setup_log();
 
-    println!("Hello, world!");
+    info!("Hello, world!");
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let mut channel = session.open_channel(1).unwrap();
     channel
@@ -85,10 +86,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/github-comment-poster.rs
+++ b/ofborg/src/bin/github-comment-poster.rs
@@ -1,4 +1,5 @@
 use amqp::Basic;
+use log::{info, log};
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
 use ofborg::tasks;
@@ -68,10 +69,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/log-message-collector.rs
+++ b/ofborg/src/bin/log-message-collector.rs
@@ -1,3 +1,4 @@
+use log::{info, log};
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
 use ofborg::tasks;
@@ -11,7 +12,7 @@ fn main() {
     ofborg::setup_log();
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let mut channel = session.open_channel(1).unwrap();
 
@@ -71,10 +72,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/log-message-generator.rs
+++ b/ofborg/src/bin/log-message-generator.rs
@@ -1,3 +1,4 @@
+use log::{info, log};
 use ofborg::config;
 use ofborg::easyamqp;
 use ofborg::message::{buildjob, Pr, Repo};
@@ -13,9 +14,9 @@ fn main() {
     ofborg::setup_log();
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
-    println!("About to open channel #1");
+    info!("About to open channel #1");
     let mut chan = session.open_channel(1).unwrap();
 
     let mut receiver = notifyworker::ChannelNotificationReceiver::new(&mut chan, 0);
@@ -39,7 +40,7 @@ fn main() {
     };
 
     loop {
-        println!("Starting a new build simulation");
+        info!("Starting a new build simulation");
         let mut actions =
             build::JobActions::new(&cfg.nix.system, &cfg.runner.identity, &job, &mut receiver);
         actions.log_started(vec![], vec![]);

--- a/ofborg/src/bin/mass-rebuilder.rs
+++ b/ofborg/src/bin/mass-rebuilder.rs
@@ -1,4 +1,5 @@
 use amqp::Basic;
+use log::{error, info, log};
 use ofborg::checkout;
 use ofborg::config;
 use ofborg::easyamqp::{self, TypedWrappers};
@@ -15,7 +16,7 @@ fn main() {
 
     if memory_info.avail < 8 * 1024 * 1024 {
         // seems this stuff is in kilobytes?
-        println!(
+        error!(
             "Less than 8Gb of memory available (got {:.2}Gb). Aborting.",
             (memory_info.avail as f32) / 1024.0 / 1024.0
         );
@@ -26,10 +27,10 @@ fn main() {
 
     ofborg::setup_log();
 
-    println!("Hello, world!");
+    info!("Hello, world!");
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let mut channel = session.open_channel(1).unwrap();
 
@@ -82,10 +83,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/bin/stats.rs
+++ b/ofborg/src/bin/stats.rs
@@ -1,5 +1,6 @@
 use amqp::Basic;
 use hyper::server::{Request, Response, Server};
+use log::{info, log};
 use ofborg::easyamqp::TypedWrappers;
 use ofborg::{config, easyamqp, stats, tasks, worker};
 
@@ -10,10 +11,10 @@ fn main() {
     let cfg = config::load(env::args().nth(1).unwrap().as_ref());
     ofborg::setup_log();
 
-    println!("Hello, world!");
+    info!("Hello, world!");
 
     let mut session = easyamqp::session_from_config(&cfg.rabbitmq).unwrap();
-    println!("Connected to rabbitmq");
+    info!("Connected to rabbitmq");
 
     let events = stats::RabbitMQ::new(
         &format!("{}-{}", cfg.runner.identity.clone(), cfg.nix.system.clone()),
@@ -78,7 +79,7 @@ fn main() {
 
     thread::spawn(|| {
         let addr = "0.0.0.0:9898";
-        println!("listening addr {:?}", addr);
+        info!("listening addr {:?}", addr);
         Server::http(addr)
             .unwrap()
             .handle(move |_: Request, res: Response| {
@@ -89,10 +90,10 @@ fn main() {
 
     channel.start_consuming();
 
-    println!("Finished consuming?");
+    info!("Finished consuming?");
 
     channel.close(200, "Bye").unwrap();
-    println!("Closed the channel");
+    info!("Closed the channel");
     session.close(200, "Good Bye");
-    println!("Closed the session... EOF");
+    info!("Closed the session... EOF");
 }

--- a/ofborg/src/commitstatus.rs
+++ b/ofborg/src/commitstatus.rs
@@ -46,8 +46,8 @@ impl<'a> CommitStatus<'a> {
 
     pub fn set(&self, state: hubcaps::statuses::State) -> Result<(), CommitStatusError> {
         let desc = if self.description.len() >= 140 {
-            eprintln!(
-                "Warning: description is over 140 char; truncating: {:?}",
+            warn!(
+                "description is over 140 char; truncating: {:?}",
                 &self.description
             );
             self.description.chars().take(140).collect()

--- a/ofborg/src/config.rs
+++ b/ofborg/src/config.rs
@@ -197,11 +197,11 @@ impl GithubAppVendingMachine {
 
             match lookup_gh.app().find_repo_installation(owner, repo) {
                 Ok(install_id) => {
-                    debug!("Received install ID {:#?}", install_id);
+                    debug!("Received install ID {:?}", install_id);
                     Some(install_id.id)
                 }
                 Err(e) => {
-                    warn!("Error during install ID lookup: {:#?}", e);
+                    warn!("Error during install ID lookup: {:?}", e);
                     None
                 }
             }

--- a/ofborg/src/nixenv.rs
+++ b/ofborg/src/nixenv.rs
@@ -155,7 +155,7 @@ impl Error {
                 }
             }
             Error::UncleanEvaluation(warnings) => {
-                format!("nix-env did not evaluate cleanly:\n {:#?}", warnings)
+                format!("nix-env did not evaluate cleanly:\n {:?}", warnings)
             }
             Error::StatsParse(mut fd, seek, parse_err) => {
                 let mut buffer = Vec::new();

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -261,11 +261,11 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
     type J = buildjob::BuildJob;
 
     fn msg_to_job(&self, _: &Deliver, _: &BasicProperties, body: &[u8]) -> Result<Self::J, String> {
-        println!("lmao I got a job?");
+        info!("lmao I got a job?");
         match buildjob::from(body) {
             Ok(e) => Ok(e),
             Err(e) => {
-                println!("{:?}", String::from_utf8(body.to_vec()));
+                error!("{:?}", String::from_utf8(body.to_vec()));
                 panic!("{:?}", e);
             }
         }
@@ -316,7 +316,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             return;
         }
 
-        println!(
+        info!(
             "Got path: {:?}, determining which ones we can build ",
             refpath
         );
@@ -332,7 +332,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             .map(|(attr, _)| attr)
             .collect();
 
-        println!(
+        info!(
             "Can build: '{}', Cannot build: '{}'",
             can_build.join(", "),
             cannot_build_attrs.join(", ")
@@ -372,17 +372,17 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
             },
         };
 
-        println!("ok built ({:?}), building", status);
-        println!("Lines:\n-----8<-----");
+        info!("ok built ({:?}), building", status);
+        info!("Lines:\n-----8<-----");
         actions
             .log_snippet()
             .iter()
-            .inspect(|x| println!("{}", x))
+            .inspect(|x| info!("{}", x))
             .last();
-        println!("----->8-----");
+        info!("----->8-----");
 
         actions.build_finished(status, can_build, cannot_build_attrs);
-        println!("Done!");
+        info!("Done!");
     }
 }
 

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -575,7 +575,7 @@ fn request_reviews(maint: &maintainers::ImpactedMaintainers, pull: &hubcaps::pul
                         team_reviewers: vec![],
                     })
             {
-                println!("Failure requesting a review from {}: {:?}", maintainer, e,);
+                warn!("Failure requesting a review from {}: {:?}", maintainer, e,);
             }
         }
     }

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -575,7 +575,7 @@ fn request_reviews(maint: &maintainers::ImpactedMaintainers, pull: &hubcaps::pul
                         team_reviewers: vec![],
                     })
             {
-                println!("Failure requesting a review from {}: {:#?}", maintainer, e,);
+                println!("Failure requesting a review from {}: {:?}", maintainer, e,);
             }
         }
     }

--- a/ofborg/src/tasks/eval/stdenvs.rs
+++ b/ofborg/src/tasks/eval/stdenvs.rs
@@ -101,12 +101,12 @@ impl Stdenvs {
             true,
         );
 
-        println!("{:?}", result);
+        info!("{:?}", result);
 
         match result {
             Ok(mut out) => Some(file_to_str(&mut out)),
             Err(mut out) => {
-                println!("{:?}", file_to_str(&mut out));
+                warn!("{:?}", file_to_str(&mut out));
                 None
             }
         }

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -211,7 +211,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
         match eval_result {
             EvalWorkerError::CommitStatusWrite(e) => {
                 eprintln!(
-                    "Failed to write commit status, got error: {:#?}, marking internal error",
+                    "Failed to write commit status, got error: {:?}, marking internal error",
                     e
                 );
                 let issue_ref = self.repo.issue(self.job.pr.number);
@@ -219,7 +219,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
             }
             EvalWorkerError::EvalError(eval::Error::CommitStatusWrite(e)) => {
                 eprintln!(
-                    "Failed to write commit status, got error: {:#?}, marking internal error",
+                    "Failed to write commit status, got error: {:?}, marking internal error",
                     e
                 );
                 let issue_ref = self.repo.issue(self.job.pr.number);
@@ -228,7 +228,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
             EvalWorkerError::EvalError(eval::Error::Fail(msg)) => {
                 self.update_status(msg.clone(), None, hubcaps::statuses::State::Failure)
                     .unwrap_or_else(|e| {
-                        panic!("Failed to set plain status: {}; e: {:#?}", msg, e);
+                        panic!("Failed to set plain status: {}; e: {:?}", msg, e);
                     });
             }
             EvalWorkerError::EvalError(eval::Error::FailWithGist(msg, filename, content)) => {
@@ -239,7 +239,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
                 )
                 .unwrap_or_else(|e| {
                     panic!(
-                        "Failed to set status with a gist: {}, {}, {}; e: {:#?}",
+                        "Failed to set status with a gist: {}, {}, {}; e: {:?}",
                         msg, filename, content, e
                     );
                 });
@@ -469,7 +469,7 @@ fn schedule_builds(
 ) -> Vec<worker::Action> {
     let mut response = vec![];
     info!(
-        "Scheduling build jobs {:#?} on arches {:#?}",
+        "Scheduling build jobs {:?} on arches {:?}",
         builds, auto_schedule_build_archs
     );
     for buildjob in builds {

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -163,8 +163,8 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
         state: hubcaps::statuses::State,
     ) -> Result<(), hubcaps::Error> {
         let description = if description.len() >= 140 {
-            eprintln!(
-                "Warning: description is over 140 char; truncating: {:?}",
+            warn!(
+                "description is over 140 char; truncating: {:?}",
                 &description
             );
             description.chars().take(140).collect()
@@ -210,7 +210,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
 
         match eval_result {
             EvalWorkerError::CommitStatusWrite(e) => {
-                eprintln!(
+                error!(
                     "Failed to write commit status, got error: {:?}, marking internal error",
                     e
                 );
@@ -218,7 +218,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
                 update_labels(&issue_ref, &[String::from("ofborg-internal-error")], &[]);
             }
             EvalWorkerError::EvalError(eval::Error::CommitStatusWrite(e)) => {
-                eprintln!(
+                error!(
                     "Failed to write commit status, got error: {:?}, marking internal error",
                     e
                 );
@@ -379,7 +379,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
 
         evaluation_strategy.after_merge(&mut overall_status)?;
 
-        println!("Got path: {:?}, building", refpath);
+        info!("Got path: {:?}, building", refpath);
         overall_status
             .set_with_description("Beginning Evaluations", hubcaps::statuses::State::Pending)?;
 
@@ -532,7 +532,8 @@ pub fn update_labels(issue: &hubcaps::issues::IssueRef, add: &[String], remove: 
         .iter()
         .map(|l| l.name.clone())
         .collect();
-    println!("Already: {:?}", existing);
+    info!("Already: {:?}", existing);
+
     let to_add = add
         .iter()
         .filter(|l| !existing.contains(l)) // Remove labels already on the issue

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -30,7 +30,7 @@ impl worker::SimpleWorker for GitHubCommentWorker {
         match serde_json::from_slice(body) {
             Ok(e) => Ok(e),
             Err(e) => {
-                println!(
+                error!(
                     "Failed to deserialize IsssueComment: {:?}",
                     String::from_utf8(body.to_vec())
                 );
@@ -55,15 +55,15 @@ impl worker::SimpleWorker for GitHubCommentWorker {
         );
 
         if build_destinations.is_empty() {
-            println!("No build destinations for: {:?}", job);
+            info!("No build destinations for: {:?}", job);
             // Don't process comments if they can't build anything
             return vec![worker::Action::Ack];
         }
 
-        println!("Got job: {:?}", job);
+        info!("Got job: {:?}", job);
 
         let instructions = commentparser::parse(&job.comment.body);
-        println!("Instructions: {:?}", instructions);
+        info!("Instructions: {:?}", instructions);
 
         let pr = self
             .github

--- a/ofborg/src/tasks/githubcommentposter.rs
+++ b/ofborg/src/tasks/githubcommentposter.rs
@@ -70,7 +70,7 @@ impl worker::SimpleWorker for GitHubCommentPoster {
         }
 
         for check in checks {
-            println!(":{:?}", check);
+            info!(":{:?}", check);
 
             let check_create_attempt = self
                 .github_vend

--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -44,7 +44,7 @@ fn validate_path_segment(segment: &PathBuf) -> Result<(), String> {
     if segment.components().all(|component| match component {
         Component::Normal(_) => true,
         e => {
-            println!("Invalid path component: {:?}", e);
+            warn!("Invalid path component: {:?}", e);
             false
         }
     }) {


### PR DESCRIPTION
Currently, our logs are a bit inconsistent, with some being
`{e,}println!`s and others utilizing macros from the `log` crate. One
line might look like `INFO:ofborg::tasks::evaluate: Removing labels:
[]`, while the next might look like `Already: []`.

---

My hope is that this will keep related logging together. There have been a few `ofborg-internal-errors` labeled recently, yet not showing up in the logs. If I'm lucky, this will alleviate that issue.

Since the plan seems to be, in the long run, to switch to the `slog` family of crates, this is more of a temporary solution.

I didn't touch the `{e,}println!`s inside tests because I didn't really see a point. Easily remedied, though, if preferred.