### PR TITLE
Cargo.toml: enable debug symbols in release profile

### DIFF
--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -29,6 +29,9 @@ sys-info = "0.5.6"
 chrono = "0.4.6"
 separator = "0.4.1"
 
+[profile.release]
+debug = true
+
 [patch.crates-io]
 #hubcaps = { path = "../hubcaps" }
 #amq-proto = { path = "rust-amq-proto" }


### PR DESCRIPTION
Maybe now we'll be able to read the backtraces generated by
`error-chain` via `hubcaps`.

---

EDIT: It didn't.

:(