### PR TITLE
More logging

### DIFF
--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -373,7 +373,8 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         };
 
         info!("ok built ({:?}), building", status);
-        info!("Lines:\n-----8<-----");
+        info!("Lines:");
+        info!("-----8<-----");
         actions
             .log_snippet()
             .iter()


### PR DESCRIPTION
Avoid cluttering logs further.

Also, split out the `info!` with a newline to make logging more consistent.