### PR TITLE
{checkout,clone}: redirect output to /dev/null

### DIFF
--- a/ofborg/src/clone.rs
+++ b/ofborg/src/clone.rs
@@ -4,7 +4,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub struct Lock {
     lock: Option<fs::File>,
@@ -67,6 +67,7 @@ pub trait GitClonable {
             .args(self.extra_clone_args())
             .arg(&self.clone_from())
             .arg(&self.clone_to())
+            .stdout(Stdio::null())
             .status()?;
 
         lock.unlock();
@@ -93,6 +94,7 @@ pub trait GitClonable {
             .arg("fetch")
             .arg("origin")
             .current_dir(self.clone_to())
+            .stdout(Stdio::null())
             .status()?;
 
         lock.unlock();
@@ -112,6 +114,8 @@ pub trait GitClonable {
             .arg("am")
             .arg("--abort")
             .current_dir(self.clone_to())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()?;
 
         info!("git merge --abort");
@@ -119,6 +123,8 @@ pub trait GitClonable {
             .arg("merge")
             .arg("--abort")
             .current_dir(self.clone_to())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()?;
 
         info!("git reset --hard");
@@ -126,6 +132,7 @@ pub trait GitClonable {
             .arg("reset")
             .arg("--hard")
             .current_dir(self.clone_to())
+            .stdout(Stdio::null())
             .status()?;
 
         lock.unlock();
@@ -137,11 +144,11 @@ pub trait GitClonable {
         let mut lock = self.lock()?;
 
         debug!("git checkout {:?}", git_ref);
-
         let result = Command::new("git")
             .arg("checkout")
             .arg(git_ref)
             .current_dir(self.clone_to())
+            .stdout(Stdio::null())
             .status()?;
 
         lock.unlock();

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -544,13 +544,13 @@ pub fn update_labels(issueref: &hubcaps::issues::IssueRef, add: &[String], remov
 
     info!(
         "Labeling issue #{}: + {:?} , - {:?}, = {:?}",
-        issue.id, to_add, to_remove, existing
+        issue.number, to_add, to_remove, existing
     );
 
     l.add(to_add.clone()).unwrap_or_else(|e| {
         panic!(
             "Failed to add labels {:?} to issue #{}: {:?}",
-            to_add, issue.id, e
+            to_add, issue.number, e
         )
     });
 
@@ -558,7 +558,7 @@ pub fn update_labels(issueref: &hubcaps::issues::IssueRef, add: &[String], remov
         l.remove(&label).unwrap_or_else(|e| {
             panic!(
                 "Failed to remove label {:?} from issue #{}: {:?}",
-                label, issue.id, e
+                label, issue.number, e
             )
         });
     }


### PR DESCRIPTION
It fills the logs with typically-useless information. We don't really
care about the novels people write in their commit messages.

The only `git` commands that were left unmodified are the ones where we
use their output in some way (and thus, it isn't printed to stdout/err
anyways).

---

There is a chance that this discards actual error information. However, in the past... *checks calendar* 4 days I've been a log-watcher, I've only seen innocuous output from `git` that might be useful or interesting if it was in an interactive session and not just a byproduct of our various checks.