### PR TITLE
Nix1 removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ sudo: true
 matrix:
   include:
     - name: cargo pedantry
-      script: nix-shell --run checkPhase --arg useNix1 false -A mozilla-rust-overlay
-    - name: checkPhase - Nix 2
-      script: nix-shell --run checkPhase --arg useNix1 false
-    - name: checkPhase - Nix 1
-      script: nix-shell --run checkPhase --arg useNix1 true
+      script: nix-shell --run checkPhase -A mozilla-rust-overlay
+    - name: checkPhase
+      script: nix-shell --run checkPhase
     - name: nix-build
       script: nix-build ./default.nix -A ofborg.rs -A ofborg.php

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -752,7 +752,7 @@ mod tests {
         assert_run(
             ret,
             Expect::Fail,
-            vec!["You just can't", "assertion failed"],
+            vec!["You just can't", "assertion", "failed"],
         );
     }
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
   overlays = [
     (import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz))
   ];
-}, useNix1 ? false }:
+} }:
 
 let
   # A random Nixpkgs revision *before* the default glibc
@@ -29,8 +29,7 @@ let
       php
       curl
       bash
-    ]
-      ++ stdenv.lib.optional useNix1 oldpkgs.nix1;
+    ];
 
     # HISTFILE = "${src}/.bash_hist";
   };
@@ -84,7 +83,6 @@ let
       pkgconfig
       git
     ]
-      ++ stdenv.lib.optional useNix1 oldpkgs.nix1
       ++ stdenv.lib.optional stdenv.isDarwin pkgs.darwin.Security;
 
     postHook = ''


### PR DESCRIPTION
As of NixOS/nixpkgs@7121160, nix1 has been removed from Nixpkgs. Thus, we
remove it here.

---

Also, fix a failing test as of Nix 2.3.4:
Nix 2.3.4 now shows the assertion that failed since NixOS/nix@307bcb9, changing
the message we need to check against.

---

/me is happy because now he no longer has to deal with the 13 locally-failing tests when in Nix1 mode