### PR TITLE
ghevent: add missing variants

### DIFF
--- a/ofborg/src/ghevent/pullrequestevent.rs
+++ b/ofborg/src/ghevent/pullrequestevent.rs
@@ -45,6 +45,9 @@ pub enum PullRequestAction {
     Opened,
     Edited,
     Closed,
+    ReadyForReview,
+    Locked,
+    Unlocked,
     Reopened,
     Synchronize,
 }


### PR DESCRIPTION
So we don't see log messages that are literal pages long. Pulled from
here: https://developer.github.com/v3/activity/events/types/#pullrequestevent