### PR TITLE
Pass build nixpkgs to mass-rebuilder binary

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -305,6 +305,13 @@ impl Nix {
             .collect();
         nixpath.push(nixpkgspath);
 
+        // If BUILD_NIXPKGS_PATH is set, forward its value through
+        // <nixpkgs-ofborg> in NIX_PATH. This is for when Nix evaluation needs a
+        // nixpkgs version for testing utilities
+        if let Ok(build_nixpkgs) = env::var("BUILD_NIXPKGS_PATH") {
+            nixpath.push(format!("nixpkgs-ofborg={}", build_nixpkgs))
+        }
+
         let mut command = op.command();
         op.args(&mut command);
 

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -445,7 +445,11 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 vec![
                     String::from("--arg"),
                     String::from("pkgs"),
-                    String::from("import ./. {}"),
+                    // lib tests only need a working pkgs version for supporting
+                    // tests, so we use the nixpkgs used by ofborg's build such
+                    // that stdenv rebuilds and such don't affect how much we
+                    // need to build
+                    String::from("import <nixpkgs-ofborg> {}"),
                     String::from("./lib/tests/release.nix"),
                 ],
                 self.nix.clone(),


### PR DESCRIPTION
To allow lib tests only be dependent on the nixpkgs' lib, not the pkgs
of it. This allows ofborg to run the lib tests even when there's stdenv rebuilds like in https://github.com/NixOS/nixpkgs/pull/85951

This depends on https://github.com/NixOS/nixpkgs/pull/86024, don't merge before that is merged.

I have only built the binaries with `nix-build -A ofborg.rs`, not sure how to test this otherwise.