### PR TITLE
config.public.json: add cole-h to trusted_users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -27,6 +27,7 @@
             "c0bw3b",
             "cdepillabout",
             "cleverca22",
+            "cole-h",
             "copumpkin",
             "coreyoconnor",
             "dezgeg",


### PR DESCRIPTION
This will let me build packages like `fish` on darwin, to try and catch
any new regressions (there's been one in each of the past two bumps I've
submitted...).