### PR TITLE
make messages persistent

### DIFF
--- a/ofborg/src/easylapin.rs
+++ b/ofborg/src/easylapin.rs
@@ -190,13 +190,19 @@ async fn action_deliver(
             let key = msg.routing_key.take().unwrap_or_else(|| "".to_owned());
             log::debug!("action publish {}", exch);
 
+            let mut props = BasicProperties::default().with_delivery_mode(2); // persistent.
+
+            if let Some(s) = msg.content_type {
+                props = props.with_content_type(s.into());
+            }
+
             let _confirmaton = chan
                 .basic_publish(
                     &exch,
                     &key,
                     BasicPublishOptions::default(),
                     msg.content,
-                    BasicProperties::default(),
+                    props,
                 )
                 .await?
                 .await?;

--- a/ofborg/src/notifyworker.rs
+++ b/ofborg/src/notifyworker.rs
@@ -82,6 +82,7 @@ impl<'a> NotificationReceiver for ChannelNotificationReceiver<'a> {
 
                 let props = BasicProperties {
                     content_type: msg.content_type,
+                    delivery_mode: Some(2), // persistent
                     ..Default::default()
                 };
                 self.channel

--- a/ofborg/src/worker.rs
+++ b/ofborg/src/worker.rs
@@ -104,6 +104,7 @@ impl<T: SimpleWorker + Send> amqp::Consumer for Worker<T> {
 
                     let props = BasicProperties {
                         content_type: msg.content_type,
+                        delivery_mode: Some(2), // persistent
                         ..Default::default()
                     };
                     channel


### PR DESCRIPTION
Should ensure we don't loose pending builds or evaluations when rabbitmq
restarts.