### PR TITLE
remove static lifetimes from easylapin

### DIFF
--- a/ofborg/src/easyamqp.rs
+++ b/ofborg/src/easyamqp.rs
@@ -303,7 +303,7 @@ pub trait ChannelExt {
     fn bind_queue(&mut self, config: BindQueueConfig) -> Result<(), Self::Error>;
 }
 
-pub trait ConsumerExt<C> {
+pub trait ConsumerExt<'a, C> {
     type Error;
     type Handle;
     fn consume(self, callback: C, config: ConsumeConfig) -> Result<Self::Handle, Self::Error>;
@@ -351,7 +351,7 @@ impl ChannelExt for amqp::Channel {
     }
 }
 
-impl<C: amqp::Consumer + 'static> ConsumerExt<C> for amqp::Channel {
+impl<C: amqp::Consumer + 'static> ConsumerExt<'_, C> for amqp::Channel {
     type Error = amqp::AMQPError;
     type Handle = Self;
 

--- a/ofborg/src/easylapin.rs
+++ b/ofborg/src/easylapin.rs
@@ -80,9 +80,9 @@ impl ChannelExt for CloseOnDrop<Channel> {
     }
 }
 
-impl<W: SimpleWorker + 'static> ConsumerExt<W> for CloseOnDrop<Channel> {
+impl<'a, W: SimpleWorker + 'a> ConsumerExt<'a, W> for CloseOnDrop<Channel> {
     type Error = lapin::Error;
-    type Handle = Pin<Box<dyn Future<Output = ()> + 'static>>;
+    type Handle = Pin<Box<dyn Future<Output = ()> + 'a>>;
 
     fn consume(self, mut worker: W, config: ConsumeConfig) -> Result<Self::Handle, Self::Error> {
         task::block_on(self.basic_qos(1, BasicQosOptions::default()))?;
@@ -130,9 +130,9 @@ impl<'a> NotificationReceiver for ChannelNotificationReceiver<'a> {
 // but one could probably be implemented in terms of the other instead.
 pub struct NotifyChannel(pub CloseOnDrop<Channel>);
 
-impl<W: SimpleNotifyWorker + 'static> ConsumerExt<W> for NotifyChannel {
+impl<'a, W: SimpleNotifyWorker + 'a> ConsumerExt<'a, W> for NotifyChannel {
     type Error = lapin::Error;
-    type Handle = Pin<Box<dyn Future<Output = ()> + 'static>>;
+    type Handle = Pin<Box<dyn Future<Output = ()> + 'a>>;
 
     fn consume(self, worker: W, config: ConsumeConfig) -> Result<Self::Handle, Self::Error> {
         task::block_on(self.0.basic_qos(1, BasicQosOptions::default()))?;


### PR DESCRIPTION
Unlike amqp::Consumer lapin channels don't need to have a 'static
lifetime, the workers just need to live at least as long as the channel.