### PR TITLE
skip stdenv rebuilds

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -4,12 +4,15 @@ use crate::ofborg::partition_result;
 
 use std::collections::HashMap;
 use std::env;
+use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs;
+use std::io;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use tracing::{debug, info};
 
 use tempfile::tempfile;
 
@@ -135,6 +138,47 @@ impl Nix {
         let mut n = self.clone();
         n.limit_supported_systems = false;
         n
+    }
+
+    pub fn safely_query_cache_for_attr(
+        &self,
+        nixpkgs: &Path,
+        file: File,
+        attr: String,
+    ) -> Result<bool, Box<dyn Error>> {
+        let mut command = self.safe_command::<&OsStr>(&Operation::Instantiate, nixpkgs, &[], &[]);
+        self.set_attrs_command(&mut command, file, vec![attr]);
+        let output = command
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .output()?;
+        debug!("{}", String::from_utf8(output.stderr)?.trim());
+
+        let drv = String::from_utf8(output.stdout)?;
+        let output = Command::new("nix-store")
+            .args(&["-q", "--binding", "out"])
+            .arg(drv.trim())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .output()?;
+        debug!("{}", String::from_utf8(output.stderr)?.trim());
+        if !output.status.success() {
+            let err = io::Error::new(io::ErrorKind::Other, "Could not evaluate stdenv");
+            return Err(Box::new(err));
+        }
+
+        let out = String::from_utf8(output.stdout)?;
+        info!("stdenv {}", out);
+        let output = Command::new("nix-store")
+            .args(&["--option", "store", "https://cache.nixos.org"])
+            .args(&["-q", "--size"])
+            .arg(out.trim())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::null())
+            .output()?;
+        debug!("{}", String::from_utf8(output.stderr)?.trim());
+
+        Ok(output.status.success())
     }
 
     pub fn safely_partition_instantiable_attrs(

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -413,7 +413,10 @@ mod tests {
     const SYSTEM: &str = "x86_64-darwin";
 
     fn nix() -> nix::Nix {
+        let path = env::var("PATH").unwrap();
+        let test_path = format!("{}/test-nix/bin:{}", env!("CARGO_MANIFEST_DIR"), path);
         let remote = env::var("NIX_REMOTE").unwrap_or("".to_owned());
+        env::set_var("PATH", test_path);
         nix::Nix::new("x86_64-linux".to_owned(), remote, 1800, None)
     }
 

--- a/ofborg/test-srcs/build-pr/default.nix
+++ b/ofborg/test-srcs/build-pr/default.nix
@@ -2,6 +2,11 @@ let
   builder = builtins.storePath <ofborg-test-bash>;
 in
 {
+  stdenv = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/x86_64/c5aabb0d603e2c1ea05f5a93b3be82437f5ebf31/bootstrap-tools.tar.xz";
+    sha256 = "a5ce9c155ed09397614646c9717fc7cd94b1023d7b76b618d409e4fefd6e9d39";
+  };
+
   success = derivation {
     name = "success";
     system = builtins.currentSystem;

--- a/ofborg/test-srcs/build/default.nix
+++ b/ofborg/test-srcs/build/default.nix
@@ -2,6 +2,11 @@ let
   builder = builtins.storePath <ofborg-test-bash>;
 in
 {
+  stdenv = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/x86_64/c5aabb0d603e2c1ea05f5a93b3be82437f5ebf31/bootstrap-tools.tar.xz";
+    sha256 = "a5ce9c155ed09397614646c9717fc7cd94b1023d7b76b618d409e4fefd6e9d39";
+  };
+
   success = derivation {
     name = "success";
     system = builtins.currentSystem;

--- a/ofborg/test-srcs/make-stdenv-pr.sh
+++ b/ofborg/test-srcs/make-stdenv-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eu
+
+bare=$1
+co=$2
+
+makepr() {
+    git init --bare "$bare"
+    git clone "$bare" "$co"
+    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" --allow-empty -m "empty master commit"
+    git -C "$co" push origin master
+
+    cp build/* "$co/"
+    git -C "$co" add .
+    git -C "$co" checkout -B staging
+    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
+    git -C "$co" push origin staging
+
+    cp stdenv-pr/*  "$co/"
+    git -C "$co" checkout -b my-cool-pr
+    git -C "$co" add .
+    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
+    git -C "$co" push origin my-cool-pr:refs/pull/1/head
+}
+
+makepr >&2
+git -C "$co" rev-parse HEAD

--- a/ofborg/test-srcs/stdenv-pr/default.nix
+++ b/ofborg/test-srcs/stdenv-pr/default.nix
@@ -1,0 +1,16 @@
+let
+  builder = builtins.storePath <ofborg-test-bash>;
+in
+{
+  stdenv = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/x86_64/c5aabb0d603e2c1ea05f5a93b3be82437f5ebf31/bootstrap-tools.tar.xz";
+    sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+  };
+
+  success = derivation {
+    name = "success";
+    system = builtins.currentSystem;
+    inherit builder;
+    args = [ "-c" "echo hi; printf '1\n2\n3\n4\n'; echo ${toString builtins.currentTime} > $out" ];
+  };
+}


### PR DESCRIPTION
Before attempting builds check if the stdenv for this branch is
available in the cache.  If this is not the case then either the merge
request is a mass rebuild or it's targeting a branch like staging.