### PR TITLE
config.public.json: add zowoq to trusted users for darwin access

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -109,7 +109,8 @@
             "xrelkd",
             "yegortimoshenko",
             "yurrriq",
-            "zimbatm"
+            "zimbatm",
+            "zowoq"
         ]
     },
     "tag_paths": {


### PR DESCRIPTION
I'd like check builds on darwin to catch any failures in my PRs before they get merged.

I have access to darwin hardware so I can resolve any issues that ofborg identifies in my PRs.

cc @adisbladis @marsam @Mic92 committers who have seen most of my PRs.