### PR TITLE
handle converted_to_draft events

### DIFF
--- a/ofborg/src/ghevent/pullrequestevent.rs
+++ b/ofborg/src/ghevent/pullrequestevent.rs
@@ -50,6 +50,7 @@ pub enum PullRequestAction {
     Unlocked,
     Reopened,
     Synchronize,
+    ConvertedToDraft,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This really shouldn't break the evaluation filter.