### PR TITLE
tasks/eval: label package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ofborg
 
+test
+
 ## Guidelines
 
 1. Review the code of all PRs before triggering the bot on them.

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -102,11 +102,20 @@ impl<'a> NixpkgsStrategy<'a> {
     }
 
     /// Takes a list of commit messages and checks if any of them contains the
-    /// standard version bump indicator, `->`; if any do, the `8.has: package
-    /// (update)` label is added.
-    fn tag_from_commits(&self, msgs: &[String]) {
-        for msg in msgs {
-            if msg.contains("->") {
+    /// standard version bump indicator, `->`, at the second index after
+    /// splitting on whitespace; if any do, the `8.has: package (update)` label
+    /// is added.
+    ///
+    /// * `attr: 1.0.0 -> 1.1.0` will get the label
+    /// * `attr: move from fetchTarball -> fetchFromGitHub` will not get the
+    /// label
+    fn tag_from_commits(&self, messages: &[String]) {
+        for message in messages {
+            let msg: Vec<&str> = message.split(char::is_whitespace).collect();
+
+            // attr: 1.0.0 -> 1.1.0
+            //   0     1   2    3
+            if msg.get(2) == Some(&"->") {
                 update_labels(
                     &self.issue_ref,
                     &[String::from("8.has: package (update)")],


### PR DESCRIPTION
Package version updates that follow the well-established and widely-used
commit message format of `attr: 1.0.0 -> 2.0.0` will now be labeled with
the `8.has: package (update)` label. Only ASCII arrows (e.g.  `->`) are
accepted -- Unicode arrows will not trigger the addition of this label.

---

Due to the naivety of this approach, anybody who adds an ASCII arrow to their commit title will get an "update" label, e.g. `attr: builtins.fetchTarball -> fetchFromGitHub`.

I can't think of a robust solution for detecting these kinds of false-positives, but am open to suggestions for mitigating this. I don't know if it's worth it to add a dependency on `regex` for this one function, but it's already in our dependency graph...

1) Split on whitespace and check if `split[2] == "->"` (safely, of course) -- the above example would split to `attr:`, `1.0.0`, `->`, and `2.0.0`
    * Downside: `lib/cli: encodeGNUCommandLine -> toGNUCommandLineShell` is a package update (no change from the current solution, but would protect against e.g. `lib/cli: change encodeGNUCommandLine -> toGNUCommandLineShell`)
2) Regex match on `.*: .* -> .*`
3) Something else?

---

Closes #318.