### PR TITLE
lapin: 1.0.0-beta4 -> 1.0.0-rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,23 +18,23 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "6.0.0-rc3"
+version = "6.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "amq-protocol-codegen 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "amq-protocol-tcp 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "amq-protocol-types 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "amq-protocol-uri 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-codegen 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-tcp 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-types 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-uri 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie-factory 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 6.0.0-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "amq-protocol-codegen"
-version = "6.0.0-rc3"
+version = "6.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "amq-protocol-types 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-types 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,17 +42,17 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "6.0.0-rc3"
+version = "6.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "amq-protocol-uri 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-uri 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tcp-stream 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tcp-stream 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "amq-protocol-types"
-version = "6.0.0-rc3"
+version = "6.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie-factory 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "6.0.0-rc3"
+version = "6.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,6 +159,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -531,11 +536,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lapin"
-version = "1.0.0-beta4"
+version = "1.0.0-rc6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "amq-protocol 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "amq-protocol-codegen 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-codegen 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-task 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -811,7 +816,7 @@ dependencies = [
  "hubcaps 0.3.16 (git+https://github.com/grahamc/hubcaps.git)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lapin 1.0.0-beta4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lapin 1.0.0-rc6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -894,6 +899,16 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pem"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1262,12 +1277,13 @@ dependencies = [
 
 [[package]]
 name = "tcp-stream"
-version = "0.15.4"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1516,11 +1532,11 @@ dependencies = [
 [metadata]
 "checksum addr2line 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
-"checksum amq-protocol 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "fc2af3b0b15738172334d196a3b98e651fcdbbcecf2069138f5bbedf400a3d6d"
-"checksum amq-protocol-codegen 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3f2c370a138e85cec1656cb741de76ca80cf25c9a63f5bf611a7af6152315f2"
-"checksum amq-protocol-tcp 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "bc78407975f9b9cb73d01abf84996a54a64058493c147ba6c2bd3149df0937f7"
-"checksum amq-protocol-types 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "4425e82ba6069abf1132abae0395dd2d59bc0f5bd25b4001208dbfa7701f135f"
-"checksum amq-protocol-uri 6.0.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "9551b95be48c02825f0944eb45b372112e2ac4f76e1ab684c8bc789e62d8a7e4"
+"checksum amq-protocol 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)" = "f107cf5f6960ae3ddf1c5b5dea85a68a4f6d70c51ae66b8df86180860145da1b"
+"checksum amq-protocol-codegen 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)" = "1f51a7891d6185faa895186b2a604ce9618088626bb2097f09fcb28bfc102636"
+"checksum amq-protocol-tcp 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)" = "b60861763928b4776f3b129595a13caf9caa533e89ed98436613c49d5041d887"
+"checksum amq-protocol-types 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)" = "00e2c0836916200c43f462f35dea50b520a551c4d755e07492e389b19befba95"
+"checksum amq-protocol-uri 6.0.0-rc7 (registry+https://github.com/rust-lang/crates.io-index)" = "7b891342708e4ed231278ef5bb8ccccf6ca1542fc56d02e7a1cff548ac2ad215"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -1530,6 +1546,7 @@ dependencies = [
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.48 (registry+https://github.com/rust-lang/crates.io-index)" = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -1578,7 +1595,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lapin 1.0.0-beta4 (registry+https://github.com/rust-lang/crates.io-index)" = "daceedfb02915683f986b8860f3ed65530e8a33fcc77b3a0f52dffeb08e482c3"
+"checksum lapin 1.0.0-rc6 (registry+https://github.com/rust-lang/crates.io-index)" = "6fcc19a0b0a5c9de7fd25ec93a590ab0c12780729fb72cf68ecb8fc08b1005e3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 "checksum libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
@@ -1616,6 +1633,7 @@ dependencies = [
 "checksum openssl-sys 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)" = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
 "checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 "checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+"checksum pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1581760c757a756a41f0ee3ff01256227bdf64cb752839779b95ffb01c59793"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
@@ -1663,7 +1681,7 @@ dependencies = [
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum syn 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "95b5f192649e48a5302a13f2feb224df883b98933222369e4b3b0fe2a5447269"
 "checksum sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "58283a48c9212afcade2069f8bbf7ded6a7bdbf4888d2defba72244c8e5f423c"
-"checksum tcp-stream 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cffaa277f6a7eae762f9ba79da149e239e1940b392d6dd32c1cd3bb27ca6d9dd"
+"checksum tcp-stream 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bf936a66fc83b53e50a754b2dc3ca607c1149710b5e96f0546e053a9764303e"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -119,9 +119,9 @@ rec {
       };
       "amq-protocol" = rec {
         crateName = "amq-protocol";
-        version = "6.0.0-rc3";
+        version = "6.0.0-rc7";
         edition = "2018";
-        sha256 = "0v9x190dzgjviw9nj86grsxws7v5isws75ni6hiiff2pn6qg6apw";
+        sha256 = "06ys8l0qd031z26nprhsqmq6skwals2ylpav3kgkvbk0d5gwy1zi";
         libName = "amq_protocol";
         authors = [
           "Marc-Antoine Perennou <%arc-Antoine@Perennou.com>"
@@ -171,9 +171,9 @@ rec {
       };
       "amq-protocol-codegen" = rec {
         crateName = "amq-protocol-codegen";
-        version = "6.0.0-rc3";
+        version = "6.0.0-rc7";
         edition = "2018";
-        sha256 = "1whm4cazcyhsc6zzaqwsbkr0ra3cwwfp9jsn2vn5rs1ql5qc7wn3";
+        sha256 = "0di623y8pcpw15zhkckbca480qg99ih2lsqqjnlgm1b13n4sfl8z";
         libName = "amq_protocol_codegen";
         authors = [
           "Marc-Antoine Perennou <%arc-Antoine@Perennou.com>"
@@ -201,9 +201,9 @@ rec {
       };
       "amq-protocol-tcp" = rec {
         crateName = "amq-protocol-tcp";
-        version = "6.0.0-rc3";
+        version = "6.0.0-rc7";
         edition = "2018";
-        sha256 = "1xrp17gljcdxqak7n51w95c419jldacq9gqss1rwpfgrfmwl0y5w";
+        sha256 = "11yq8589vi0kcr1rivc97r9sm75g7jhrb58j7dppgd1875v6225n";
         libName = "amq_protocol_tcp";
         authors = [
           "Marc-Antoine Perennou <%arc-Antoine@Perennou.com>"
@@ -237,9 +237,9 @@ rec {
       };
       "amq-protocol-types" = rec {
         crateName = "amq-protocol-types";
-        version = "6.0.0-rc3";
+        version = "6.0.0-rc7";
         edition = "2018";
-        sha256 = "0pqk3xqaggwd400l0nyjbc7vqn9dvnah7bmb688vz6h6lqmyh9a4";
+        sha256 = "15dsxydv32g3j9sf0mfpqi8sa85ma3m5vwv2yi1hq80nd61w1qh0";
         libName = "amq_protocol_types";
         authors = [
           "Marc-Antoine Perennou <%arc-Antoine@Perennou.com>"
@@ -270,9 +270,9 @@ rec {
       };
       "amq-protocol-uri" = rec {
         crateName = "amq-protocol-uri";
-        version = "6.0.0-rc3";
+        version = "6.0.0-rc7";
         edition = "2018";
-        sha256 = "1r57v1i9wy5wr22bc6kfyz22lbhifarlbss415gq40lcwidvjlcm";
+        sha256 = "05fj5an4ixfgl7kh4vf55xaa2v6grj6bpxcf4wqx4klff11172bv";
         libName = "amq_protocol_uri";
         authors = [
           "Marc-Antoine Perennou <%arc-Antoine@Perennou.com>"
@@ -548,6 +548,20 @@ rec {
           }
         ];
         
+      };
+      "base64 0.11.0" = rec {
+        crateName = "base64";
+        version = "0.11.0";
+        edition = "2018";
+        sha256 = "1iqmims6yvr6vwzyy54qd672zw29ipjj17p8klcr578c9ajpw6xl";
+        authors = [
+          "Alice Maz <alice@alicemaz.com>"
+          "Marshall Pierce <marshall@mpierce.org>"
+        ];
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
       "base64 0.9.3" = rec {
         crateName = "base64";
@@ -1535,9 +1549,9 @@ rec {
       };
       "lapin" = rec {
         crateName = "lapin";
-        version = "1.0.0-beta4";
+        version = "1.0.0-rc6";
         edition = "2018";
-        sha256 = "1hw2wh4fpzrdynhb6xyc7yiyhc2msqz0z1mqhvwq6mli0bxyvkns";
+        sha256 = "1qq5225w13ybivv2rdwzfa02ghdh19ckmjays9zxxjd5n2h1kk3g";
         authors = [
           "Geoffroy Couprie <geo.couprie@gmail.com>"
           "Marc-Antoine Perennou <Marc-Antoine@Perennou.com>"
@@ -2642,6 +2656,30 @@ rec {
           "deadlock_detection" = [ "petgraph" "thread-id" "backtrace" ];
         };
       };
+      "pem" = rec {
+        crateName = "pem";
+        version = "0.7.0";
+        edition = "2018";
+        sha256 = "14wpql0znpxrg6bq6lmp9kvbs9v24l0zzqqf3yj5d9spqxh1fn51";
+        authors = [
+          "Jonathan Creekmore <jonathan@thecreekmores.org>"
+        ];
+        dependencies = [
+          {
+            name = "base64";
+            packageId = "base64 0.11.0";
+          }
+          {
+            name = "lazy_static";
+            packageId = "lazy_static";
+          }
+          {
+            name = "regex";
+            packageId = "regex";
+          }
+        ];
+        
+      };
       "percent-encoding 1.0.1" = rec {
         crateName = "percent-encoding";
         version = "1.0.1";
@@ -3664,9 +3702,9 @@ rec {
       };
       "tcp-stream" = rec {
         crateName = "tcp-stream";
-        version = "0.15.4";
+        version = "0.19.1";
         edition = "2018";
-        sha256 = "1pfrlryb4fydq4rdvmljnd01k7i3kqadlydsz5ifgsm7yrvs5yng";
+        sha256 = "0gihcjbkl1bfakq9cphbf54i2z30rb1jsjvm1bjm6fy8dyk3dy9v";
         libName = "tcp_stream";
         authors = [
           "Marc-Antoine Perennou <Marc-Antoine@Perennou.com>"
@@ -3685,19 +3723,27 @@ rec {
           {
             name = "native-tls";
             packageId = "native-tls";
+            rename = "native-tls-crate";
+            optional = true;
+          }
+          {
+            name = "pem";
+            packageId = "pem";
             optional = true;
           }
         ];
         features = {
           "dangerous-configuration" = [ "rustls-connector/dangerous-configuration" ];
           "default" = [ "native-tls" ];
+          "native-tls" = [ "native-tls-crate" "pem" ];
           "quic" = [ "rustls-connector/quic" ];
           "rustls" = [ "rustls-native-certs" ];
-          "rustls-native-certs" = [ "rustls-connector" "rustls-connector/native-certs" ];
-          "rustls-webpki-roots-certs" = [ "rustls-connector" "rustls-connector/webpki-roots-certs" ];
+          "rustls-common" = [ "rustls-connector" "p12" ];
+          "rustls-native-certs" = [ "rustls-common" "rustls-connector/native-certs" ];
+          "rustls-webpki-roots-certs" = [ "rustls-common" "rustls-connector/webpki-roots-certs" ];
           "vendored-openssl" = [ "openssl/vendored" ];
         };
-        resolvedDefaultFeatures = [ "native-tls" ];
+        resolvedDefaultFeatures = [ "native-tls" "native-tls-crate" "pem" ];
       };
       "tempfile 2.2.0" = rec {
         crateName = "tempfile";

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -27,4 +27,4 @@ chrono = "0.4.6"
 separator = "0.4.1"
 
 async-std = "=1.5.0"
-lapin = "=1.0.0-beta4"
+lapin = "1.0.0-rc6"

--- a/ofborg/src/stats.rs
+++ b/ofborg/src/stats.rs
@@ -1,6 +1,5 @@
 use async_std::task;
 use lapin::options::BasicPublishOptions;
-use lapin::CloseOnDrop;
 
 include!(concat!(env!("OUT_DIR"), "/events.rs"));
 
@@ -25,8 +24,8 @@ pub struct RabbitMQ<C> {
     channel: C,
 }
 
-impl RabbitMQ<CloseOnDrop<lapin::Channel>> {
-    pub fn from_lapin(identity: &str, channel: CloseOnDrop<lapin::Channel>) -> Self {
+impl RabbitMQ<lapin::Channel> {
+    pub fn from_lapin(identity: &str, channel: lapin::Channel) -> Self {
         RabbitMQ {
             identity: identity.to_owned(),
             channel,
@@ -34,7 +33,7 @@ impl RabbitMQ<CloseOnDrop<lapin::Channel>> {
     }
 }
 
-impl SysEvents for RabbitMQ<CloseOnDrop<lapin::Channel>> {
+impl SysEvents for RabbitMQ<lapin::Channel> {
     fn notify(&mut self, event: Event) {
         let props = lapin::BasicProperties::default().with_content_type("application/json".into());
         task::block_on(async {


### PR DESCRIPTION
Turns out this was totally fine.

This reverts commit 16d8b612cb0c6cd1f3f4c20bd63df441d816e74d.