### PR TITLE
move lib-tests to a build

### DIFF
--- a/ofborg/src/commentparser.rs
+++ b/ofborg/src/commentparser.rs
@@ -72,6 +72,7 @@ pub enum Instruction {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum Subset {
+    LibTests,
     Nixpkgs,
     NixOS,
 }

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -16,6 +16,7 @@ use tempfile::tempfile;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum File {
     DefaultNixpkgs,
+    ReleaseLibTests,
     ReleaseNixOS,
 }
 
@@ -23,6 +24,7 @@ impl fmt::Display for File {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             File::DefaultNixpkgs => write!(f, "./default.nix"),
+            File::ReleaseLibTests => write!(f, "./lib/tests/release.nix"),
             File::ReleaseNixOS => write!(f, "./nixos/release.nix"),
         }
     }

--- a/ofborg/src/systems.rs
+++ b/ofborg/src/systems.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum System {
     X8664Linux,
     Aarch64Linux,

--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -306,6 +306,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
         };
 
         let buildfile = match job.subset {
+            Some(commentparser::Subset::LibTests) => nix::File::ReleaseLibTests,
             Some(commentparser::Subset::NixOS) => nix::File::ReleaseNixOS,
             _ => nix::File::DefaultNixpkgs,
         };

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -1,11 +1,12 @@
+use tracing::{debug_span, error, info};
+use uuid::Uuid;
+
 use crate::acl;
 use crate::commentparser;
 use crate::ghevent;
 use crate::message::{buildjob, evaluationjob, Pr, Repo};
+use crate::systems::System;
 use crate::worker;
-
-use tracing::{debug_span, error, info};
-use uuid::Uuid;
 
 pub struct GitHubCommentWorker {
     acl: acl::ACL,
@@ -104,6 +105,11 @@ impl worker::SimpleWorker for GitHubCommentWorker {
                 match instruction {
                     commentparser::Instruction::Build(subset, attrs) => {
                         let build_destinations = match subset {
+                            commentparser::Subset::LibTests => build_destinations
+                                .clone()
+                                .into_iter()
+                                .filter(|x| x == &System::X8664Linux)
+                                .collect(),
                             commentparser::Subset::NixOS => build_destinations
                                 .clone()
                                 .into_iter()


### PR DESCRIPTION
This still has problems with rebuilds since it uses the target nixpkgs
to build the tests, but it's a regular build job which doesn't block the
entire evaluator anymore. Mitigates the main problem until we decide
what to do for these kind of use cases.