### PR TITLE
config.public.json: add trailing slash to doc

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -239,7 +239,7 @@
             "doc/manual/release-notes/"
         ],
         "8.has: documentation": [
-            "doc",
+            "doc/",
             "nixos/doc"
         ],
         "8.has: module (update)": [

--- a/ofborg/src/tagger.rs
+++ b/ofborg/src/tagger.rs
@@ -255,7 +255,7 @@ impl PathsTagger {
             .possible
             .iter()
             .filter(|&(ref tag, ref _paths)| !self.selected.contains(&tag))
-            .filter(|&(ref _tag, ref paths)| paths.iter().any(|tp| path.contains(tp)))
+            .filter(|&(ref _tag, ref paths)| paths.iter().any(|tp| path.starts_with(tp)))
             .map(|(tag, _paths)| tag.clone())
             .collect();
         self.selected.append(&mut tags_to_add);


### PR DESCRIPTION
Might help with #148?

I went through the last few pages of PRs with this label and it looks evenly split between PRs that have docs and not.