### PR TITLE
.github: drop FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-patreon: ofborg


### PR DESCRIPTION
The Patreon is now defunct.

This should (hopefully) default to the org-wide FUNDING.yml linking to
the NixOS Open Collective page.