### PR TITLE
config.public.json: add danieldk to trusted users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -31,6 +31,7 @@
             "copumpkin",
             "coreyoconnor",
             "dezgeg",
+            "danieldk",
             "disassembler",
             "domenkozar",
             "doronbehar",


### PR DESCRIPTION
I am not sure when one is trusted enough to be a trusted user ;), but it would be nice to be able to test Darwin when reviewing PRs.