### PR TITLE
config.public.json: Rename the GNOME label

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -137,7 +137,7 @@
         "6.topic: fetch": [
             "pkgs/build-support/fetch"
         ],
-        "6.topic: gnome3": [
+        "6.topic: GNOME": [
             "pkgs/desktops/gnome-3",
             "nixos/modules/services/x11/desktop-managers/gnome3.nix",
             "nixos/tests/gnome3.nix",


### PR DESCRIPTION
GNOME might switch to different versioning scheme soon so gnome3 might not make sense.

cc @cole-h @worldofpeace 