### PR TITLE
Php update

### DIFF
--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "0f5ce2fac0c726036ca69a5524c59a49e2973dd4",
-  "date": "2020-05-19T01:31:20+02:00",
-  "path": "/nix/store/57j44dl147z6956rc5ks4h1ff2rbdlxp-nixpkgs-channels",
-  "sha256": "0nkk492aa7pr0d30vv1aw192wc16wpa1j02925pldc09s9m9i0r3",
+  "rev": "5aba0fe9766a7201a336249fd6cb76e0d7ba2faf",
+  "date": "2020-09-24T23:45:31-05:00",
+  "path": "/nix/store/145b69swcsfd5cninwj4x76gvfy4nikn-nixpkgs-channels",
+  "sha256": "05gawlhizp85agdpw3kpjn41vggdiywbabsbmk76r2dr513188jz",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/php/composer-env.nix
+++ b/php/composer-env.nix
@@ -1,41 +1,9 @@
 # This file originates from composer2nix
 
-{ stdenv, writeTextFile, fetchurl, php, unzip }:
+{ stdenv, writeTextFile, fetchurl, php, unzip, phpPackages }:
 
 let
-  composer = stdenv.mkDerivation {
-    name = "composer-1.6.5";
-    src = fetchurl {
-      url = https://github.com/composer/composer/releases/download/1.6.5/composer.phar;
-      sha256 = "07xkpg9y1dd4s33y3cbf7r5fphpgc39mpm066a8m9y4ffsf539f0";
-    };
-    buildInputs = [ php ];
-
-    # We must wrap the composer.phar because of the impure shebang.
-    # We cannot use patchShebangs because the executable verifies its own integrity and will detect that somebody has tampered with it.
-
-    buildCommand = ''
-      # Copy phar file
-      mkdir -p $out/share/php
-      cp $src $out/share/php/composer.phar
-      chmod 755 $out/share/php/composer.phar
-
-      # Create wrapper executable
-      mkdir -p $out/bin
-      cat > $out/bin/composer <<EOF
-      #! ${stdenv.shell} -e
-      exec ${php}/bin/php $out/share/php/composer.phar "\$@"
-      EOF
-      chmod +x $out/bin/composer
-    '';
-    meta = {
-      description = "Dependency Manager for PHP";
-      #license = stdenv.licenses.mit;
-      maintainers = [ stdenv.lib.maintainers.sander ];
-      platforms = stdenv.lib.platforms.unix;
-    };
-  };
-
+  inherit (phpPackages) composer;
   buildZipPackage = { name, src }:
     stdenv.mkDerivation {
       inherit name src;

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -1,46 +1,47 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81858eba648031903f09c76e5d8e23cd",
+    "content-hash": "d9759fb63b22e1547003ef1e9fd45f44",
     "packages": [
         {
             "name": "php-amqplib/php-amqplib",
-            "version": "v2.7.2",
+            "version": "v2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-amqplib/php-amqplib.git",
-                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b"
+                "reference": "0eaaa9d5d45335f4342f69603288883388c2fe21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/dfd3694a86f1a7394d3693485259d4074a6ec79b",
-                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/0eaaa9d5d45335f4342f69603288883388c2fe21",
+                "reference": "0eaaa9d5d45335f4342f69603288883388c2fe21",
                 "shasum": ""
             },
             "require": {
-                "ext-bcmath": "*",
                 "ext-mbstring": "*",
-                "php": ">=5.3.0"
+                "ext-sockets": "*",
+                "php": ">=5.6.3",
+                "phpseclib/phpseclib": "^2.0.0"
+            },
+            "conflict": {
+                "php": "7.4.0 - 7.4.1"
             },
             "replace": {
                 "videlalvaro/php-amqplib": "self.version"
             },
             "require-dev": {
-                "phpdocumentor/phpdocumentor": "^2.9",
-                "phpunit/phpunit": "^4.8",
-                "scrutinizer/ocular": "^1.1",
+                "ext-curl": "*",
+                "nategood/httpful": "^0.2.20",
+                "phpunit/phpunit": "^5.7|^6.5|^7.0",
                 "squizlabs/php_codesniffer": "^2.5"
-            },
-            "suggest": {
-                "ext-sockets": "Use AMQPSocketConnection"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.12-dev"
                 }
             },
             "autoload": {
@@ -58,13 +59,18 @@
                     "role": "Original Maintainer"
                 },
                 {
-                    "name": "John Kelly",
-                    "email": "johnmkelly86@gmail.com",
+                    "name": "Raúl Araya",
+                    "email": "nubeiro@gmail.com",
                     "role": "Maintainer"
                 },
                 {
-                    "name": "Raúl Araya",
-                    "email": "nubeiro@gmail.com",
+                    "name": "Luke Bakken",
+                    "email": "luke@bakken.io",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Ramūnas Dronga",
+                    "email": "github@ramuno.lt",
                     "role": "Maintainer"
                 }
             ],
@@ -75,20 +81,125 @@
                 "queue",
                 "rabbitmq"
             ],
-            "time": "2018-02-11T19:28:00+00:00"
+            "time": "2020-09-25T18:34:58+00:00"
         },
         {
-            "name": "svanderburg/composer2nix",
-            "version": "v0.0.3",
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.29",
             "source": {
                 "type": "git",
-                "url": "https://github.com/svanderburg/composer2nix.git",
-                "reference": "2fb157acaf0ecbe34436195c694637396f7258a6"
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "497856a8d997f640b4a516062f84228a772a48a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/svanderburg/composer2nix/zipball/2fb157acaf0ecbe34436195c694637396f7258a6",
-                "reference": "2fb157acaf0ecbe34436195c694637396f7258a6",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/497856a8d997f640b4a516062f84228a772a48a8",
+                "reference": "497856a8d997f640b4a516062f84228a772a48a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-08T04:24:43+00:00"
+        },
+        {
+            "name": "svanderburg/composer2nix",
+            "version": "v0.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/svanderburg/composer2nix.git",
+                "reference": "57cecaf5d9d667b47415bb7c1d1f5154be7c759e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/svanderburg/composer2nix/zipball/57cecaf5d9d667b47415bb7c1d1f5154be7c759e",
+                "reference": "57cecaf5d9d667b47415bb7c1d1f5154be7c759e",
                 "shasum": ""
             },
             "require": {
@@ -118,7 +229,7 @@
                 }
             ],
             "description": "Generate Nix expressions to build PHP composer packages",
-            "time": "2018-06-29T20:58:30+00:00"
+            "time": "2020-04-01T17:55:02+00:00"
         },
         {
             "name": "svanderburg/pndp",
@@ -168,5 +279,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/php/default.nix
+++ b/php/default.nix
@@ -4,8 +4,7 @@
 
 let
   composerEnv = import ./composer-env.nix {
-    inherit (pkgs) stdenv writeTextFile fetchurl unzip;
-    php = pkgs.php72;
+    inherit (pkgs) stdenv writeTextFile fetchurl php unzip phpPackages;
   };
 in
 import ./php-packages.nix {

--- a/php/php-packages.nix
+++ b/php/php-packages.nix
@@ -5,20 +5,30 @@ let
     "php-amqplib/php-amqplib" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "php-amqplib-php-amqplib-dfd3694a86f1a7394d3693485259d4074a6ec79b";
+        name = "php-amqplib-php-amqplib-0eaaa9d5d45335f4342f69603288883388c2fe21";
         src = fetchurl {
-          url = https://api.github.com/repos/php-amqplib/php-amqplib/zipball/dfd3694a86f1a7394d3693485259d4074a6ec79b;
-          sha256 = "1dlxgdnhy8xyx8xbp1glc7igksvsqyc3yaq76irhy09djij013ip";
+          url = https://api.github.com/repos/php-amqplib/php-amqplib/zipball/0eaaa9d5d45335f4342f69603288883388c2fe21;
+          sha256 = "0dpjy33rspmpdflhwjqb9iass8kxzbl3nj8nc3vgn9hczgaxqlfs";
+        };
+      };
+    };
+    "phpseclib/phpseclib" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpseclib-phpseclib-497856a8d997f640b4a516062f84228a772a48a8";
+        src = fetchurl {
+          url = https://api.github.com/repos/phpseclib/phpseclib/zipball/497856a8d997f640b4a516062f84228a772a48a8;
+          sha256 = "061kgl49f1zc5vdfrlmq6m1qgvqrh7jvlldfhfxya44y2vwriz1p";
         };
       };
     };
     "svanderburg/composer2nix" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "svanderburg-composer2nix-2fb157acaf0ecbe34436195c694637396f7258a6";
+        name = "svanderburg-composer2nix-57cecaf5d9d667b47415bb7c1d1f5154be7c759e";
         src = fetchurl {
-          url = https://api.github.com/repos/svanderburg/composer2nix/zipball/2fb157acaf0ecbe34436195c694637396f7258a6;
-          sha256 = "01i3kxgx7pcmxafclp8ib08nib1xh6nvr5sbl6y38rw19xhnwa0m";
+          url = https://api.github.com/repos/svanderburg/composer2nix/zipball/57cecaf5d9d667b47415bb7c1d1f5154be7c759e;
+          sha256 = "0s6fjwaf2dwzf9h83dms5wg8s3a1kcy5nmdnn7wy1ykqi3mhp61m";
         };
       };
     };


### PR DESCRIPTION
Noticed that the Hydra jobset for ofborg was failing because `php72` is gone (https://hydra.nixos.org/jobset/ofborg/release#tabs-errors).

Did literally nothing to test aside from `nix-build -A ofborg.php`.

cc @andir -- should we pin php again? There is `php73` and `php74` to choose from, at the moment.