### PR TITLE
fix sort warning

### DIFF
--- a/ofborg/src/nixstats.rs
+++ b/ofborg/src/nixstats.rs
@@ -311,7 +311,7 @@ impl<'a> EvaluationStatsDiff<'a> {
         );
 
         let mut keys = data.keys().cloned().collect::<Vec<&str>>();
-        keys.sort();
+        keys.sort_unstable();
 
         let rows = keys
             .into_iter()


### PR DESCRIPTION
The shell.nix uses nixpkgs-mozilla which can change and thus break
stuff.