### PR TITLE
config.public.json: add NickHu to trusted_users

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -79,6 +79,7 @@
             "mpickering",
             "nequissimus",
             "nh2",
+            "NickHu",
             "nlewo",
             "obadz",
             "orivej",


### PR DESCRIPTION
On quite a few occasions, it would've been nice to be able to test my nix expressions on darwin, and I don't have access to any mac machine otherwise. In particular, right now it would be nice to test this https://github.com/NixOS/nixpkgs/pull/102763#issuecomment-723525952.