### PR TITLE
Disable aliases when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ run the checks themselves like so:
 
 ```shell
 $ curl -o outpaths.nix https://raw.githubusercontent.com/NixOS/ofborg/released/ofborg/src/outpaths.nix
-$ GC_INITIAL_HEAP_SIZE=4g nix-env -f ./outpaths.nix -qaP --no-name --out-path --arg checkMeta true > out-paths
+$ GC_INITIAL_HEAP_SIZE=4g nix-env -f ./outpaths.nix -qaP --no-name --out-path --arg checkMeta true --arg allowAliases false > out-paths
 ```
 
 # Hacking

--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -2,6 +2,7 @@
 # When using as a callable script, passing `--argstr path some/path` overrides $PWD.
 #!nix-shell -p nix -i "nix-env -qaP --no-name --out-path --arg checkMeta true --argstr path $PWD -f"
 { checkMeta
+, allowAliases ? true
 , path ? ./.
 }:
 let
@@ -18,6 +19,7 @@ let
 
       nixpkgsArgs = {
         config = {
+          allowAliases = allowAliases;
           allowBroken = true;
           allowUnfree = true;
           allowInsecurePredicate = x: true;


### PR DESCRIPTION
Sometimes I run this locally when ofborg gets broken, or when ofborg is "backed up".

However, I was able to run it locally, but still fail in practice.

https://github.com/NixOS/nixpkgs/pull/104416

now, it should run correctly as:
```
$ GC_INITIAL_HEAP_SIZE=16g nix-env -f ./outpaths.nix -qaP --no-name --out-path --arg checkMeta true --arg allowAliases false --show-trace > out-paths
error: while evaluating anonymous function at /home/jon/projects/nixpkgs/outpaths.nix:46:12, called from undefined position:
while evaluating 'g' at /home/jon/projects/nixpkgs/lib/attrsets.nix:276:19, called from undefined position:
while evaluating anonymous function at /home/jon/projects/nixpkgs/pkgs/top-level/release-lib.nix:144:38, called from undefined position:
while evaluating 'isDerivation' at /home/jon/projects/nixpkgs/lib/attrsets.nix:305:18, called from /home/jon/projects/nixpkgs/pkgs/top-level/release-lib.nix:146:10:
while evaluating 'callPackageWith' at /home/jon/projects/nixpkgs/lib/customisation.nix:117:35, called from /home/jon/projects/nixpkgs/pkgs/top-level/all-packages.nix:25135:12:
while evaluating 'makeOverridable' at /home/jon/projects/nixpkgs/lib/customisation.nix:67:24, called from /home/jon/projects/nixpkgs/lib/customisation.nix:121:8:
anonymous function at /home/jon/projects/nixpkgs/pkgs/games/amoeba/default.nix:1:1 called without required argument 'xlibs', at /home/jon/projects/nixpkgs/lib/customisation.nix:69:16
```