### PR TITLE
ci: update install-nix-action to v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,22 @@ jobs:
   pedantry:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Nix
-      uses: cachix/install-nix-action@v9
-    - name: Cargo Pedantry
-      run: nix-shell --run checkPhase -A mozilla-rust-overlay
+      - uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Cargo Pedantry
+        run: nix-shell --run checkPhase -A mozilla-rust-overlay
   
   checkPhase:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v9
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Set up git
         run: |
           git config --global user.email "ofborg@example.com"
@@ -33,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v9
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: nix-build
         run: nix-build -A ofborg.rs -A ofborg.php


### PR DESCRIPTION
This fixes the `Unable to process command
'::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin'
successfully.` errors (this was deprecated by GitHub).