### PR TITLE
typo: correct base checkout message

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -385,7 +385,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
         self.check_stdenvs_before(dir);
 
         status.set_with_description(
-            "Checking original out paths",
+            "Checking out original paths",
             hubcaps::statuses::State::Pending,
         )?;
         self.check_outpaths_before(dir)?;


### PR DESCRIPTION
At present, when checking out the base branch, ofborg reports "Checking
original out paths", where I think it was intended to write "Checking
out original paths".