### PR TITLE
config.public.json: configure systemd topic label

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -215,6 +215,10 @@
         "6.topic: steam": [
             "pkgs/games/steam"
         ],
+        "6.topic: systemd": [
+            "pkgs/os-specific/linux/systemd",
+            "nixos/modules/system/boot/systemd"
+        ],
         "6.topic: TeX": [
             "pkgs/tools/typesetting/tex",
             "doc/languages-frameworks/texlive.xml"


### PR DESCRIPTION
I’ve used `nixos/modules/system/boot/systemd` to capture e.g. systemd.nix, systemd-unit-options.nix, etc. This should work as `PathTagger` just does a substring match, but I’m not sure if that’s something you’d like to depend on? If so, we’d have to move all the systemd options into a directory of their own (which might not be a bad thing anyway), or list them all out explicitly.