### PR TITLE
tasks/evaluate: error on PRs targeting nixos-* or nixpkgs-* branches

### DIFF
--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -334,6 +334,17 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
             None => String::from("master"),
         };
 
+        if target_branch.starts_with("nixos-") || target_branch.starts_with("nixpkgs-") {
+            overall_status.set_with_description(
+                "The branch you have targeted is a read-only mirror for channels. \
+                    Please target release-* or master.",
+                hubcaps::statuses::State::Error,
+            )?;
+
+            info!("PR targets a nixos-* or nixpkgs-* branch");
+            return Ok(self.actions().skip(&job));
+        };
+
         overall_status.set_with_description(
             format!("Checking out {}", &target_branch).as_ref(),
             hubcaps::statuses::State::Pending,


### PR DESCRIPTION
A PR's target branch is easy to overlook. ofborg should complain loudly
if a nixos-* or nixpkgs-* branch is the target of a PR.

https://github.com/NixOS/nixpkgs/issues/109384, https://logs.nix.samueldr.com/nixos/2021-01-14#4470635

---

Happy to bikeshed on the actual message, but I think this is the right thing to do (and probably should have been done long ago).

EDIT: pedantry fixed here: https://github.com/NixOS/ofborg/pull/547