### PR TITLE
Rename check prefixes to `ofborg`

### DIFF
--- a/ofborg/src/evalchecker.rs
+++ b/ofborg/src/evalchecker.rs
@@ -20,8 +20,8 @@ impl EvalChecker {
         }
     }
 
-    pub fn name(&self) -> String {
-        format!("grahamcofborg-eval-{}", self.name)
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn execute(&self, path: &Path) -> Result<File, File> {


### PR DESCRIPTION
* If the sha we're operating on already has checks beginning with the old
`grahamcofborg-` prefix (e.g. someone just used `@ofborg eval`, `@ofborg build`,
or `@ofborg test`), continue using that prefix.

* If the sha we're operating on doesn't have any checks beginning with the old
`grahamcofborg-` prefix, use the new `ofborg-` prefix. This will take effect on
all new PRs immediately, and after a force-push for all existing PRs.