### PR TITLE
config.public.json: add paths for the "6. topic: ocaml" tag

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -177,6 +177,14 @@
         "6.topic: nixos": [
             "nixos"
         ],
+        "6.topic: ocaml": [
+            "doc/languages-frameworks/ocaml.section.md",
+            "pkgs/top-level/ocaml-packages.nix",
+            "pkgs/development/ocaml-modules",
+            "pkgs/development/compilers/ocaml",
+            "pkgs/development/tools/ocaml",
+            "pkgs/development/compilers/reason"
+        ],
         "6.topic: pantheon": [
             "pkgs/desktops/pantheon",
             "nixos/tests/pantheon.nix",


### PR DESCRIPTION
There are some out of pkgs/development/ocaml-modules paths like
pkgs/applications/networking/jackline which would be nice, but
ultimately maintaining that list would be a bit of a nightmare.