### PR TITLE
builders: report hash errors as failures

### DIFF
--- a/ofborg/src/message/buildresult.rs
+++ b/ofborg/src/message/buildresult.rs
@@ -8,6 +8,7 @@ pub enum BuildStatus {
     Success,
     Failure,
     TimedOut,
+    HashMismatch,
     UnexpectedError { err: String },
 }
 
@@ -17,6 +18,7 @@ impl From<BuildStatus> for String {
             BuildStatus::Skipped => "No attempt".into(),
             BuildStatus::Success => "Success".into(),
             BuildStatus::Failure => "Failure".into(),
+            BuildStatus::HashMismatch => "A fixed output derivation's hash was incorrect".into(),
             BuildStatus::TimedOut => "Timed out, unknown build status".into(),
             BuildStatus::UnexpectedError { ref err } => format!("Unexpected error: {}", err),
         }
@@ -29,6 +31,7 @@ impl From<BuildStatus> for Conclusion {
             BuildStatus::Skipped => Conclusion::Neutral,
             BuildStatus::Success => Conclusion::Success,
             BuildStatus::Failure => Conclusion::Neutral,
+            BuildStatus::HashMismatch => Conclusion::Failure,
             BuildStatus::TimedOut => Conclusion::Neutral,
             BuildStatus::UnexpectedError { .. } => Conclusion::Neutral,
         }

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -365,6 +365,7 @@ pub fn wait_for_build_status(spawned: SpawnedAsyncCmd) -> BuildStatus {
             Some(0) => BuildStatus::Success,
             Some(100) => BuildStatus::Failure, // nix permanent failure
             Some(101) => BuildStatus::TimedOut, // nix build timedout
+            Some(102) => BuildStatus::HashMismatch, // Fixed Output Derivation's hash was wrong
             Some(i) => BuildStatus::UnexpectedError {
                 err: format!("command failed with exit code {}", i),
             },


### PR DESCRIPTION
Hash failures are never ignorable, so making these builds actual failures makes sense.