### PR TITLE
Remove the origin prefix from the fallback branch name in BuildWorker

### DIFF
--- a/ofborg/src/tasks/build.rs
+++ b/ofborg/src/tasks/build.rs
@@ -302,7 +302,7 @@ impl notifyworker::SimpleNotifyWorker for BuildWorker {
 
         let target_branch = match job.pr.target_branch.clone() {
             Some(x) => x,
-            None => String::from("origin/master"),
+            None => String::from("master"),
         };
 
         let buildfile = match job.subset {


### PR DESCRIPTION
The `origin/` prefix will be added by the actual git cloner later on
when `co.checkout_origin_ref` is called further down the function.