### PR TITLE
check unfree packages for deprecated aliases

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -435,7 +435,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                     String::from("."),
                     String::from("--arg"),
                     String::from("config"),
-                    String::from("{ allowAliases = false; }"),
+                    String::from("{ allowAliases = false; allowUnfree = true; }"),
                 ],
                 self.nix.clone(),
             ),


### PR DESCRIPTION
This is probably causing some regressions but after removing unfree aliases from https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/office/timedoctor/default.nix I think it is a good idea to do that.