### PR TITLE
Don't use global git config in tests

### DIFF
--- a/ofborg/test-srcs/make-maintainer-pr.sh
+++ b/ofborg/test-srcs/make-maintainer-pr.sh
@@ -4,19 +4,22 @@ set -eu
 bare=$1
 co=$2
 
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 makepr() {
     git init --bare "$bare"
     git clone "$bare" "$co"
 
     cp -r maintainers/* "$co/"
     git -C "$co" add .
-    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
+    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
     git -C "$co" push origin master
 
     cp maintainers-pr/*  "$co/"
     git -C "$co" checkout -b my-cool-pr
     git -C "$co" add .
-    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
+    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
     git -C "$co" push origin my-cool-pr:refs/pull/1/head
 }
 

--- a/ofborg/test-srcs/make-maintainer-pr.sh
+++ b/ofborg/test-srcs/make-maintainer-pr.sh
@@ -6,6 +6,8 @@ co=$2
 
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME="GrahamCOfBorg"
+export GIT_AUTHOR_EMAIL="graham+cofborg@example.com"
 
 makepr() {
     git init --bare "$bare"
@@ -13,13 +15,13 @@ makepr() {
 
     cp -r maintainers/* "$co/"
     git -C "$co" add .
-    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
+    git -C "$co" commit -m "initial repo commit"
     git -C "$co" push origin master
 
     cp maintainers-pr/*  "$co/"
     git -C "$co" checkout -b my-cool-pr
     git -C "$co" add .
-    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
+    git -C "$co" commit -m "check out this cool PR"
     git -C "$co" push origin my-cool-pr:refs/pull/1/head
 }
 

--- a/ofborg/test-srcs/make-maintainer-pr.sh
+++ b/ofborg/test-srcs/make-maintainer-pr.sh
@@ -8,6 +8,8 @@ export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_AUTHOR_NAME="GrahamCOfBorg"
 export GIT_AUTHOR_EMAIL="graham+cofborg@example.com"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
 makepr() {
     git init --bare "$bare"

--- a/ofborg/test-srcs/make-pr.sh
+++ b/ofborg/test-srcs/make-pr.sh
@@ -4,19 +4,22 @@ set -eu
 bare=$1
 co=$2
 
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 makepr() {
     git init --bare "$bare"
     git clone "$bare" "$co"
 
     cp build/* "$co/"
     git -C "$co" add .
-    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
+    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
     git -C "$co" push origin master
 
     cp build-pr/*  "$co/"
     git -C "$co" checkout -b my-cool-pr
     git -C "$co" add .
-    git -C "$co" commit --no-gpg-sign --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
+    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
     git -C "$co" push origin my-cool-pr:refs/pull/1/head
 }
 

--- a/ofborg/test-srcs/make-pr.sh
+++ b/ofborg/test-srcs/make-pr.sh
@@ -6,6 +6,8 @@ co=$2
 
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME="GrahamCOfBorg"
+export GIT_AUTHOR_EMAIL="graham+cofborg@example.com"
 
 makepr() {
     git init --bare "$bare"
@@ -13,13 +15,13 @@ makepr() {
 
     cp build/* "$co/"
     git -C "$co" add .
-    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "initial repo commit"
+    git -C "$co" commit -m "initial repo commit"
     git -C "$co" push origin master
 
     cp build-pr/*  "$co/"
     git -C "$co" checkout -b my-cool-pr
     git -C "$co" add .
-    git -C "$co" commit --author "GrahamCOfBorg <graham+cofborg@example.com>" -m "check out this cool PR"
+    git -C "$co" commit -m "check out this cool PR"
     git -C "$co" push origin my-cool-pr:refs/pull/1/head
 }
 

--- a/ofborg/test-srcs/make-pr.sh
+++ b/ofborg/test-srcs/make-pr.sh
@@ -8,6 +8,8 @@ export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_AUTHOR_NAME="GrahamCOfBorg"
 export GIT_AUTHOR_EMAIL="graham+cofborg@example.com"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
 makepr() {
     git init --bare "$bare"


### PR DESCRIPTION
The tests were failing for me because I have git configured to use
"main" instead of "master" as the default initial branch name for new
repositories.  Having the tests use global git configuration from
developer systems is just asking for trouble with non-reproducibility,
but fortunately git gives us a mechanism to disable it.

This also means we don't need to worry about GPG any more, and while
I'm here I've also used environment variables to configure the author
name and email so it doesn't have to be specified every time.
