### PR TITLE
eval aarch64-darwin rather than i686-linux

### DIFF
--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -11,8 +11,8 @@ let
     {
       supportedSystems = [
         "aarch64-linux"
-        # "aarch64-darwin" # !!!
-        "i686-linux"
+        "aarch64-darwin"
+        #"i686-linux"  # !!!
         "x86_64-linux"
         "x86_64-darwin"
       ];


### PR DESCRIPTION
I don't think anyone still runs nixpkgs-review on 32-bit x86.