### PR TITLE
always disallow aliases

### DIFF
--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -19,6 +19,7 @@ let
 
       nixpkgsArgs = {
         config = {
+          allowAliases = false;
           allowBroken = true;
           allowUnfree = true;
           allowInsecurePredicate = x: true;

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -448,18 +448,6 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 self.nix.clone(),
             ),
             EvalChecker::new(
-                "package-list-no-aliases",
-                nix::Operation::QueryPackagesJson,
-                vec![
-                    String::from("--file"),
-                    String::from("."),
-                    String::from("--arg"),
-                    String::from("config"),
-                    String::from("{ allowAliases = false; }"),
-                ],
-                self.nix.clone(),
-            ),
-            EvalChecker::new(
                 "lib-tests",
                 nix::Operation::Build,
                 vec![


### PR DESCRIPTION
remove package-list-no-aliases
this will also save us an eval

Closes https://github.com/NixOS/ofborg/issues/575

Supersedes https://github.com/NixOS/ofborg/pull/572 https://github.com/NixOS/ofborg/pull/539