### PR TITLE
tagger: aarch64-darwin is a known architecture

### DIFF
--- a/ofborg/src/tagger.rs
+++ b/ofborg/src/tagger.rs
@@ -160,6 +160,7 @@ impl RebuildTagger {
                 "x86_64-darwin" => {
                     counter_darwin += 1;
                 }
+                "aarch64-darwin" => {}
                 "x86_64-linux" => {
                     counter_linux += 1;
                 }


### PR DESCRIPTION
Prevents 'Unknown arch: "aarch64-darwin"' from cluttering up the logs.