### PR TITLE
tasks/eval/nixpkgs: build the nixos manual / options to verify them

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -485,7 +485,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
             ),
             EvalChecker::new(
                 "nixos-options",
-                nix::Operation::Instantiate,
+                nix::Operation::Build,
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),
@@ -498,7 +498,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
             ),
             EvalChecker::new(
                 "nixos-manual",
-                nix::Operation::Instantiate,
+                nix::Operation::Build,
                 vec![
                     String::from("--arg"),
                     String::from("nixpkgs"),


### PR DESCRIPTION
Just evaluating them isn't enough anymore, now that the docs are lazy.

---

Maybe we should keep the instantiate step but add the build step? idk