### PR TITLE
config.public.json: bump build_timeout_seconds to 3 hours from 1 hour

### DIFF
--- a/config.public.json
+++ b/config.public.json
@@ -121,7 +121,7 @@
     "nix": {
         "system": "x86_64-linux",
         "remote": "daemon",
-        "build_timeout_seconds": 3600,
+        "build_timeout_seconds": 10800,
         "initial_heap_size": "4g"
     }
 }


### PR DESCRIPTION
the most common isue i see on darwin builds is 'timed out after 3600 seconds' due to llvm or gcc failing to build which makes the darwin ofborg useless on many staging PR's

for example
https://logs.nix.ci/?key=nixos/nixpkgs.185972&attempt_id=a7f34cd2-8bce-4299-a4e5-d6bc6f5c434f
is being built with -j1

3 hours is picked from the time it took to build 'nixpkgs:staging-next:gcc-unwrapped.x86_64-darwin' 2h 45m 16s
https://hydra.nixos.org/build/187709773