### PR TITLE
nix: run all operations with "--option extra-experimental-features 'n…

### DIFF
--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -60,7 +60,7 @@ impl Operation {
                     "--no-out-link",
                     "--keep-going",
                     "--option",
-                    "experimental-features",
+                    "extra-experimental-features",
                     "no-url-literals",
                 ]);
             }
@@ -70,7 +70,7 @@ impl Operation {
                     "--available",
                     "--json",
                     "--option",
-                    "experimental-features",
+                    "extra-experimental-features",
                     "no-url-literals",
                 ]);
             }
@@ -82,7 +82,7 @@ impl Operation {
                     "--attr-path",
                     "--out-path",
                     "--option",
-                    "experimental-features",
+                    "extra-experimental-features",
                     "no-url-literals",
                 ]);
             }
@@ -95,12 +95,12 @@ impl Operation {
                     "--strict",
                     "--json",
                     "--option",
-                    "experimental-features",
+                    "extra-experimental-features",
                     "no-url-literals",
                 ]);
             }
             Operation::Instantiate => {
-                command.args(&["--option", "experimental-features", "no-url-literals"])
+                command.args(&["--option", "extra-experimental-features", "no-url-literals"]);
             }
             _ => (),
         };

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -56,10 +56,23 @@ impl Operation {
     fn args(&self, command: &mut Command) {
         match *self {
             Operation::Build => {
-                command.args(&["--no-out-link", "--keep-going", "--option", "experimental-features", "no-url-literals"]);
+                command.args(&[
+                    "--no-out-link",
+                    "--keep-going",
+                    "--option",
+                    "experimental-features",
+                    "no-url-literals",
+                ]);
             }
             Operation::QueryPackagesJson => {
-                command.args(&["--query", "--available", "--json", "--option", "experimental-features", "no-url-literals"]);
+                command.args(&[
+                    "--query",
+                    "--available",
+                    "--json",
+                    "--option",
+                    "experimental-features",
+                    "no-url-literals",
+                ]);
             }
             Operation::QueryPackagesOutputs => {
                 command.args(&[
@@ -70,14 +83,21 @@ impl Operation {
                     "--out-path",
                     "--option",
                     "experimental-features",
-                    "no-url-literals"
+                    "no-url-literals",
                 ]);
             }
             Operation::NoOp { ref operation } => {
                 operation.args(command);
             }
             Operation::Evaluate => {
-                command.args(&["--eval", "--strict", "--json", "--option", "experimental-features", "no-url-literals"]);
+                command.args(&[
+                    "--eval",
+                    "--strict",
+                    "--json",
+                    "--option",
+                    "experimental-features",
+                    "no-url-literals",
+                ]);
             }
             Operation::Instantiate => {
                 command.args(&["--option", "experimental-features", "no-url-literals"])

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -56,10 +56,10 @@ impl Operation {
     fn args(&self, command: &mut Command) {
         match *self {
             Operation::Build => {
-                command.args(&["--no-out-link", "--keep-going"]);
+                command.args(&["--no-out-link", "--keep-going", "--option", "experimental-features", "no-url-literals"]);
             }
             Operation::QueryPackagesJson => {
-                command.args(&["--query", "--available", "--json"]);
+                command.args(&["--query", "--available", "--json", "--option", "experimental-features", "no-url-literals"]);
             }
             Operation::QueryPackagesOutputs => {
                 command.args(&[
@@ -68,13 +68,16 @@ impl Operation {
                     "--no-name",
                     "--attr-path",
                     "--out-path",
+                    "--option",
+                    "experimental-features",
+                    "no-url-literals"
                 ]);
             }
             Operation::NoOp { ref operation } => {
                 operation.args(command);
             }
             Operation::Evaluate => {
-                command.args(&["--eval", "--strict", "--json"]);
+                command.args(&["--eval", "--strict", "--json", "--option", "experimental-features", "no-url-literals"]);
             }
             _ => (),
         };

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -79,6 +79,9 @@ impl Operation {
             Operation::Evaluate => {
                 command.args(&["--eval", "--strict", "--json", "--option", "experimental-features", "no-url-literals"]);
             }
+            Operation::Instantiate => {
+                command.args(&["--option", "experimental-features", "no-url-literals"])
+            }
             _ => (),
         };
     }


### PR DESCRIPTION
…iterals'"

https://github.com/nixos/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090



```
error: URL literals are disabled

       at /home/artturin/nixpkgs/.worktree/1/pkgs/games/tennix/default.nix:8:11:

            7|   src = fetchgit {
            8|     url = git://repo.or.cz/tennix.git;
             |           ^
            9|     rev = "refs/tags/tennix-${version}";
nix-env -qa --out-path --no-name -f outpaths.nix --arg checkMeta false      215.81s user 8.50s system 99% cpu 3:44.39 total
1 artturin@nixos ~/nixpkgs/.worktree/1 (git)-[master~1] % nix-env -qa --out-path  --no-name  -f outpaths.nix --arg checkMeta false --verbose--option extra-experimental-features 'no-url-literals'
```