### PR TITLE
config: convert PEM to DER format on the fly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1303,7 @@ dependencies = [
  "md5",
  "nom 4.2.3",
  "regex",
+ "rustls-pemfile",
  "separator",
  "serde",
  "serde_derive",
@@ -1678,11 +1685,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
 ]
 
 [[package]]

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -32,3 +32,4 @@ tempfile = "3.3.0"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 uuid = { version = "1.2", features = ["v4"] }
+rustls-pemfile = "1.0.2"


### PR DESCRIPTION
hubcaps requires a DER formatted key, but their instructions for converting PEM to DER didn't work for me. So, we rely on rustls-pemfile to parse the PEM key into DER bytes and hand that to hubcaps.

---

This is brought on by the fact that ofborg went down for ~an hour today due to this. I imagine it might be because I re-pushed the secrets and somehow the secrets were just in a Bad State? Dunno. But a small reimplementation of this auth portion in a test binary shows that this works (or at least doesn't panic).

I'll deploy this very carefully tomorrow.

NOTE: The issue is _NOT_ that we were passing the PEM file before and claiming those were DER bytes, but that the PEM-to-DER conversion process, for whatever reason, was producing DER bytes that ring (via jsonwebtoken, via hubcaps) didn't think were valid. Until this is deployed, I hackily made ring write out the DER bytes it calculated itself `from_pkcs8` and have copied that to all the machines.