### PR TITLE
log_message_collector: open log handle to ensure log file exists 

### DIFF
--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -398,6 +398,7 @@ mod tests {
                 })
             );
 
+            assert!(p.path().join("routing-key-foo/attempt-id-foo").exists());
             assert_eq!(vec![worker::Action::Ack], worker.consumer(&job));
 
             logmsg.line_number = 5;

--- a/ofborg/src/tasks/log_message_collector.rs
+++ b/ofborg/src/tasks/log_message_collector.rs
@@ -215,6 +215,11 @@ impl worker::SimpleWorker for LogMessageCollector {
             MsgType::Start(ref start) => {
                 self.write_metadata(&job.from, start)
                     .expect("failed to write metadata");
+
+                // Make sure the log content exists by opening its handle.
+                // This (hopefully) prevents builds that produce no output (for any reason) from
+                // having their logs.nix.ci link complaining about a 404.
+                let _ = self.handle_for(&job.from).unwrap();
             }
             MsgType::Msg(ref message) => {
                 let handle = self.handle_for(&job.from).unwrap();


### PR DESCRIPTION
In the past, we've seen some PRs have empty build logs, which would display a 404 if nothing was ever written to its log output. This should hopefully prevent that from happening.