### PR TITLE
Add support for building only on a single system

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ the Nixpkgs checkout (see also "[How does ofborg call
 Builds will run on all allowed machines. For more information, see the "[Trusted
 Users](#trusted-users)" section.
 
+### build_system
+
+```
+@ofborg build_system SYSTEM list of attrs
+```
+
+Same as [build](#build), but restricts building to only one platform specification
+instead of attempting to build on all allowed and supported systems.
+This can be helpful to reduce needless builds and noise when debugging a platform-specific issue.
+
+Only the currently supported Nixpkgs systems can be passed to `build_system`:
+`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`.
+
 ## Multiple Commands
 
 You can use multiple commands in a variety ways. Here are some valid

--- a/ofborg/src/systems.rs
+++ b/ofborg/src/systems.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum System {
     X8664Linux,
     Aarch64Linux,


### PR DESCRIPTION
This PR adds support for building only on a single system. The proposed syntax based on `build_system` is only a suggestion, I'm open to better ideas.

I took the liberty of breaking the comment parser into a few modular sub-parsers in the process, as it was a little convoluted previously. In any case, the parser is still using the relatively old `nom` version 4.2.3. Newer nom versions use functions instead of macros (see the [migration guide](https://github.com/rust-bakery/nom/blob/main/doc/upgrading_to_nom_5.md#from-macros-to-functions)). At some point the parser should be rewritten using this new style, but I didn't do it in this PR to keep it simple.

Note: I can't test the PR using a live builder as I'm not running one. I'm opening the PR anyway as the README says this is OK due to the lack of test environments for ofborg.

Closes #232.