### PR TITLE
eval/nixpkgs: parse more commit messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "brace-expand"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3adb80ee272c844254166ea32c8ae11c211b3639a293fdde41b1645b6be2c62"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1297,7 @@ name = "ofborg"
 version = "0.1.9"
 dependencies = [
  "async-std",
+ "brace-expand",
  "chrono",
  "either",
  "fs2",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example commit titles and the builds they will start:
 | `vim: 1.0.0 -> 2.0.0`                                                 | `vim`                                                    |
 | `vagrant: Fix dependencies for version 2.0.2 `                        | `vagrant`                                                |
 | `python36Packages.requests,python27Packages.requests: 1.0.0 -> 2.0.0` | `python36Packages.requests`, `python27Packages.requests` |
-| `python{2,3}Packages.requests: 1.0.0 -> 2.0.0`                        | `python2Packages.requests`, `python3Packages.requests`   |
+| `python{27,310}Packages.requests: 1.0.0 -> 2.0.0`                        | `python27Packages.requests`, `python310Packages.requests`   |
 
 When opening a PR with multiple commits, ofborg creates a single build job for
 all detected packages. If multiple commits get pushed to a PR one-by-one, each

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example commit titles and the builds they will start:
 | `vim: 1.0.0 -> 2.0.0`                                                 | `vim`                                                    |
 | `vagrant: Fix dependencies for version 2.0.2 `                        | `vagrant`                                                |
 | `python36Packages.requests,python27Packages.requests: 1.0.0 -> 2.0.0` | `python36Packages.requests`, `python27Packages.requests` |
-| `python{2,3}Packages.requests: 1.0.0 -> 2.0.0`                        | _nothing_                                                |
+| `python{2,3}Packages.requests: 1.0.0 -> 2.0.0`                        | `python2Packages.requests`, `python3Packages.requests`   |
 
 When opening a PR with multiple commits, ofborg creates a single build job for
 all detected packages. If multiple commits get pushed to a PR one-by-one, each

--- a/ofborg/Cargo.toml
+++ b/ofborg/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 async-std = { version = "=1.12.0", features = ["unstable", "tokio1"] }
+brace-expand = "0.1.0"
 chrono = "0.4.22"
 either = "1.8.0"
 fs2 = "0.4.3"

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -16,7 +16,6 @@ use crate::tasks::evaluate::{get_prefix, make_gist, update_labels};
 
 use std::path::Path;
 
-use brace_expand::brace_expand;
 use chrono::Utc;
 use hubcaps::checks::{CheckRunOptions, CheckRunState, Conclusion, Output};
 use hubcaps::gists::Gists;
@@ -626,7 +625,10 @@ fn parse_commit_messages(messages: &[String]) -> Vec<String> {
             // Convert "foo: some notes" in to "foo"
             line.split_once(':').map(|(pre, _)| pre.trim())
         })
-        .flat_map(|line| brace_expand(&format!("{{{}}}", line)))
+        // NOTE: This transforms `{foo,bar}` into `{{foo,bar}}` and `foo,bar` into `{foo,bar}`,
+        // which allows both the old style (`foo,bar`) and the new style (`{foo,bar}`) to expand to
+        // `foo` and `bar`.
+        .flat_map(|line| brace_expand::brace_expand(&format!("{{{}}}", line)))
         .map(|line| line.trim().to_owned())
         .collect()
 }


### PR DESCRIPTION
Add support for expanding the Bash-like brace syntax <s>and for removing bracketed prefixes like [Backport ...]</s> <i>[that was stupid; those are found in the PR titles, not the commit messages]</i>.