### PR TITLE
eval/nixpkgs: make no-aliases checks use deeper eval

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -446,7 +446,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
             ),
             EvalChecker::new(
                 "package-list-no-aliases",
-                nix::Operation::QueryPackagesJson,
+                nix::Operation::QueryPackagesOutputs,
                 vec![
                     String::from("--file"),
                     String::from("."),


### PR DESCRIPTION
Right now alias usage is only caught more or less for `callPackage` args, but if an alias is accessed as (for example) `buildPackages.pkgconfig` in the derivation, then ofborg will show all green for the `package-list-no-aliases` check despite the derivation actually failing on systems with `allowAliases = false`

This solves the problem by having ofborg eval derivation output paths instead of just a shallow eval package list to ensure there is no alias usage in the derivation (it won't catch things like `passthru.pkg-config = buildPackages.pkgconfig` but that's probably acceptable)

I'm open to renaming the check to `package-outputs-no-aliases` to reflect the change in functionality

A few examples of what this would have caught are https://github.com/NixOS/nixpkgs/pull/230188#pullrequestreview-1415772214 and https://github.com/NixOS/nixpkgs/pull/236329#issuecomment-1580292218, but there are a lot more as it seems to be a recurring issue

The difference in eval timing went from ~8 seconds to ~63 seconds for that check on my laptop and so it is a fairly expensive change, but other than something like #594, I don't know a better way to reliably catch this problem