### PR TITLE
eval/nixpkgs,outpaths: fix alias checking

### DIFF
--- a/ofborg/src/outpaths.nix
+++ b/ofborg/src/outpaths.nix
@@ -19,6 +19,7 @@ let
 
       nixpkgsArgs = {
         config = {
+          allowAliases = false;
           allowBroken = true;
           allowUnfree = true;
           allowInsecurePredicate = x: true;

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -445,6 +445,18 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 self.nix.clone(),
             ),
             EvalChecker::new(
+                "package-list-with-aliases",
+                nix::Operation::QueryPackagesJson,
+                vec![
+                    String::from("--file"),
+                    String::from("."),
+                    String::from("--arg"),
+                    String::from("config"),
+                    String::from("{ allowAliases = true; }"),
+                ],
+                self.nix.clone(),
+            ),
+            EvalChecker::new(
                 "lib-tests",
                 nix::Operation::Build,
                 vec![

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -445,18 +445,6 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
                 self.nix.clone(),
             ),
             EvalChecker::new(
-                "package-list-no-aliases",
-                nix::Operation::QueryPackagesJson,
-                vec![
-                    String::from("--file"),
-                    String::from("."),
-                    String::from("--arg"),
-                    String::from("config"),
-                    String::from("{ allowAliases = false; }"),
-                ],
-                self.nix.clone(),
-            ),
-            EvalChecker::new(
                 "lib-tests",
                 nix::Operation::Build,
                 vec![


### PR DESCRIPTION
This basically does an approach like #594 but also adds an eval step to check whether the package set still shallow evals with aliases enabled

This does seem to catch at least typos in `aliases.nix` and should hopefully catch whatever else we care about in there. This does not increase ofborg eval time since it effectively changes default outpath calculation and replaces `packages-list-no-aliases` by `packages-list-with-aliases`

Alternative to #643
Closes #575
Supersedes #572 #539