### PR TITLE
clone: more forcefully clean clones of untracked files and empty dirs

### DIFF
--- a/ofborg/src/clone.rs
+++ b/ofborg/src/clone.rs
@@ -137,6 +137,16 @@ pub trait GitClonable {
             .stdout(Stdio::null())
             .status()?;
 
+        debug!("git clean -x -d --force");
+        Command::new("git")
+            .arg("clean")
+            .arg("-x")
+            .arg("-d")
+            .arg("--force")
+            .current_dir(self.clone_to())
+            .stdout(Stdio::null())
+            .status()?;
+
         lock.unlock();
 
         Ok(())


### PR DESCRIPTION
This should fix the erroneous error at https://logs.ofborg.org/?attempt_id=6c11441a-6d97-47a2-968b-57581683ef63&key=nixos%2Fnixpkgs.252154

Basically on darwin with a case-insensitive filesystem, when checking out from commit NixOS/nixpkgs@17532e1af40a6d406a1e615afcc47a6308ca61a4 on PR NixOS/nixpkgs#252154 (which has a case clash) and then trying to later do a clean checkout, git leaves an empty directory behind due to the clash

When the nixpkgs tree was then later evaluated after NixOS/nixpkgs@f87dc390d0b6ff5fe66fdea89c2700d19dfd154b (which removed the case clash), the empty directory was still there in the local clone which got copied to the nix store and the build then failed due to spurious files/directories