### PR TITLE
cope with maintainer entries using a non-github contact

### DIFF
--- a/ofborg/src/maintainers.nix
+++ b/ofborg/src/maintainers.nix
@@ -73,20 +73,22 @@ let
     (pkg: anyMatchingFiles pkg.filenames)
     attrsWithFilenames;
 
-  listToPing = pkgs.lib.lists.flatten
-    (builtins.map
-      (pkg:
-        builtins.map (maintainer: {
+  listToPing = pkgs.lib.lists.flatten (
+    builtins.map (
+      pkg:
+      builtins.map
+        (maintainer: {
           handle = pkgs.lib.toLower maintainer.github;
           packageName = pkg.name;
           dueToFiles = pkg.filenames;
         })
-        (builtins.filter
-          (maintainer:
-            pkgs.lib.hasAttrByPath ["github"] maintainer)
-          pkg.maintainers)
-      )
-      attrsWithModifiedFiles);
+        (
+          builtins.filter (
+            maintainer: pkgs.lib.hasAttrByPath [ "github" ] maintainer
+          ) pkg.maintainers
+        )
+    ) attrsWithModifiedFiles
+  );
 
   byMaintainer = pkgs.lib.lists.foldr
     (ping: collector: collector // { "${ping.handle}" = [ { inherit (ping) packageName dueToFiles; } ] ++ (collector."${ping.handle}" or []); })

--- a/ofborg/src/maintainers.nix
+++ b/ofborg/src/maintainers.nix
@@ -81,7 +81,10 @@ let
           packageName = pkg.name;
           dueToFiles = pkg.filenames;
         })
-        pkg.maintainers
+        (builtins.filter
+          (maintainer:
+            pkgs.lib.hasAttrByPath ["github"] maintainer)
+          pkg.maintainers)
       )
       attrsWithModifiedFiles);
 


### PR DESCRIPTION
There has been discussion (https://github.com/NixOS/nixpkgs/pull/273146#issuecomment-1848780888) implying that the current `ofborg` implementation may have issues coping with our year-long proven maintainer list data model, but I could not find a corresponding issue report. Therefore, I tried to come up with a fix that should help against the `listToPing` function failing.

If there are more details about the issues faced, sharing them would be shared. This might allow me to improve this PR.

Of course this does not replace the need to provide ping handlers for the other contact entry variants, which will be processed in separate PRs.