### PR TITLE
ofborg/src/maintainers.nix: look up files pointed by "pos" attribute

### DIFF
--- a/ofborg/src/maintainers.nix
+++ b/ofborg/src/maintainers.nix
@@ -62,6 +62,17 @@ let
             #(builtins.unsafeGetAttrPos "name" drv)
             (builtins.unsafeGetAttrPos "pname" drv)
             (builtins.unsafeGetAttrPos "version" drv)
+
+            # Use ".meta.position" for cases when most of the package is
+            # defined in a "common" section and the only place where
+            # reference to the file with a derivation the "pos"
+            # attribute.
+            #
+            # ".meta.position" has the following form:
+            #   "pkgs/tools/package-management/nix/default.nix:155"
+            # We transform it to the following:
+            #   { file = "pkgs/tools/package-management/nix/default.nix"; }
+            { file = pkgs.lib.head (pkgs.lib.splitString ":" (drv.meta.position or "")); }
           ]
         )));
 


### PR DESCRIPTION
Sometimes most of attributes for a package are defined outside the file
that defines it. Examples are `openjdk` and `nix`.

At least `openjdk` defined `pos` attribute to guide `nix edit` to open
the right file. Let's extend `ofborg` to do the same.

Before the change (with `pos` applied to `nix_2_3`):

    $ printf '[["nix_2_3"]]' > attrs.json; \
      printf '["pkgs/tools/package-management/nix/default.nix"]' > paths.json; \
      nix-instantiate --eval maintainers.nix --arg changedattrsjson ./attrs.json --arg changedpathsjson ./paths.json
    { }

After the change:

    $ printf '[["nix_2_3"]]' > attrs.json; \
      printf '["pkgs/tools/package-management/nix/default.nix"]' > paths.json; \
      nix-instantiate --eval maintainers.nix --arg changedattrsjson ./attrs.json --arg changedpathsjson ./paths.json
    { flokli = <CODE>; raitobezarius = <CODE>; }