### PR TITLE
Support multiple evaluators on a single machine

### DIFF
--- a/ofborg/src/bin/mass-rebuilder.rs
+++ b/ofborg/src/bin/mass-rebuilder.rs
@@ -35,7 +35,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let conn = easylapin::from_config(&cfg.rabbitmq)?;
     let mut chan = task::block_on(conn.create_channel())?;
 
-    let cloner = checkout::cached_cloner(Path::new(&cfg.checkout.root));
+    let root = Path::new(&cfg.checkout.root);
+    let cloner = checkout::cached_cloner(&root.join(cfg.runner.instance.to_string()));
     let nix = cfg.nix();
 
     let events = stats::RabbitMq::from_lapin(&cfg.whoami(), task::block_on(conn.create_channel())?);

--- a/ofborg/src/clone.rs
+++ b/ofborg/src/clone.rs
@@ -147,6 +147,13 @@ pub trait GitClonable {
             .stdout(Stdio::null())
             .status()?;
 
+        debug!("git gc");
+        Command::new("git")
+            .arg("gc")
+            .current_dir(self.clone_to())
+            .stdout(Stdio::null())
+            .status()?;
+
         lock.unlock();
 
         Ok(())

--- a/ofborg/src/config.rs
+++ b/ofborg/src/config.rs
@@ -64,8 +64,14 @@ pub struct LogStorage {
     pub path: String,
 }
 
+const fn default_instance() -> u8 {
+    1
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RunnerConfig {
+    #[serde(default = "default_instance")]
+    pub instance: u8,
     pub identity: String,
     pub repos: Option<Vec<String>>,
     #[serde(default = "Default::default")]


### PR DESCRIPTION
This has been deployed for the past week or so and nothing bad happened (...after I worked out all the initial kinks -- if you saw out-of-space errors followed by me prodding ofborg to re-eval... no you didn't).

We now run 3 evaluators on each of the 5 machines we have access to through EM. I saw about 160GiB peak when all 3 were running the outpaths evaluation at the same time, out of a total of 256GiB of RAM. This (hopefully) leaves room for the single builder that resides on the same machine as well as for the outpaths check to consume even more ( :roll_eyes: ) memory.

This also seems to more than handle the (current) Nixpkgs PR cadence, as all the machines chewed through the ~160 queue in about 10 hours:

![image](https://github.com/NixOS/ofborg/assets/28582702/e7af6c55-8840-4a56-9d8f-c6c1a7dfafc9)

We also run `git gc` every time we clone / before we clone so as to help curb the inode usage of these perpetual Nixpkgs checkouts. Before this, I had seen checkouts of more than 70GiB on disk!!! It's not fast (I think it takes 10 minutes tops), but it certainly helps cut down on inode clutter.

---

It's not beautiful, but it works.