### PR TITLE
report build failures as failures

### DIFF
--- a/ofborg/src/message/buildresult.rs
+++ b/ofborg/src/message/buildresult.rs
@@ -30,10 +30,10 @@ impl From<BuildStatus> for Conclusion {
         match status {
             BuildStatus::Skipped => Conclusion::Skipped,
             BuildStatus::Success => Conclusion::Success,
-            BuildStatus::Failure => Conclusion::Neutral,
+            BuildStatus::Failure => Conclusion::Failure,
             BuildStatus::HashMismatch => Conclusion::Failure,
             BuildStatus::TimedOut => Conclusion::Neutral,
-            BuildStatus::UnexpectedError { .. } => Conclusion::Neutral,
+            BuildStatus::UnexpectedError { .. } => Conclusion::Failure,
         }
     }
 }

--- a/ofborg/src/tasks/githubcommentposter.rs
+++ b/ofborg/src/tasks/githubcommentposter.rs
@@ -384,7 +384,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
                 status: Some(CheckRunState::Completed),
-                conclusion: Some(Conclusion::Neutral),
+                conclusion: Some(Conclusion::Failure),
                 details_url: Some(
                     "https://logs.ofborg.org/?key=nixos/nixpkgs.2345&attempt_id=neatattemptid"
                         .to_string()
@@ -621,7 +621,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
                 status: Some(CheckRunState::Completed),
-                conclusion: Some(Conclusion::Neutral),
+                conclusion: Some(Conclusion::Failure),
                 details_url: Some(
                     "https://logs.ofborg.org/?key=nixos/nixpkgs.2345&attempt_id=neatattemptid"
                         .to_string()


### PR DESCRIPTION
It is far too easy to miss clear failures when we report them as neutral. Not only does this not register them in GitHub visually as a failure, but once all checks have completed successfully GitHub collapses the checks UI and shows the PR as fully successfully checked.

We're already merging PRs that are failing checks, it's just not as visible. This change will at least provide visibility into those failing checks, to allow us to make better informed decisions when proceeding to merge anyway.

Note: I have little knowledge of what I'm doing, but this seems to be the correct place to change this.
