### PR TITLE
README: remove stale advice about cargo2nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,7 @@ $ nix-build -A ofborg.rs # build ofborg
 Currently there is no easy way to set up a test instance of ofborg. If `cargo
 check` and `cargo test` both succeed, feel free to Pull Request your changes.
 Make sure to format your code with `cargo fmt` and check for additional warnings
-with `cargo clippy`. If you added, removed, or updated the dependencies, also be
-sure to update Cargo.nix by running
-[`./nix/update-crates.sh`](./nix/update-crates.sh).
+with `cargo clippy`.
 
 To disable warnings as errors, run your command with an empty `RUSTFLAGS`. For
 example:


### PR DESCRIPTION
The file has been gone since https://github.com/NixOS/ofborg/commit/0d5bae416f86920276763f1f6aa1b402d328ca10