### PR TITLE
Fix `Access to /private is forbidden in restricted mode`

### DIFF
--- a/ofborg/src/checkout.rs
+++ b/ofborg/src/checkout.rs
@@ -91,7 +91,8 @@ impl CachedProjectCo {
 
         // let build_dir = self.build_dir();
 
-        Ok(self.clone_to().to_str().unwrap().to_string())
+        let canonicalized = fs::canonicalize(self.clone_to()).unwrap();
+        Ok(canonicalized.to_str().unwrap().to_string())
     }
 
     pub fn fetch_pr(&self, pr_id: u64) -> Result<(), Error> {


### PR DESCRIPTION
This error happens on Darwin since /var is a symlink to /private and /var is put into the allowed paths (since we specify that). By canonicalizing the path first, the /private path should be allowed instead, fixing the issue. The research and fix proposal come from @lilyinstarlight and I am very thankful for both of them.