### PR TITLE
Small improvements to check runs

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -174,6 +174,10 @@ fn parse_commit_messages(messages: &[String]) -> Vec<String> {
             // Convert "foo: some notes" in to "foo"
             line.split_once(':').map(|(pre, _)| pre.trim())
         })
+        .filter(|line| {
+            // When a prefix contains a slash, it targets a certain file, but not a buildable package.
+            !line.contains("/")
+        })
         // NOTE: This transforms `{foo,bar}` into `{{foo,bar}}` and `foo,bar` into `{foo,bar}`,
         // which allows both the old style (`foo,bar`) and the new style (`{foo,bar}`) to expand to
         // `foo` and `bar`.
@@ -228,6 +232,7 @@ mod tests {
               Merge pull request #34414 from dotlambda/postfix
               foo,bar: something here: yeah
               firefox{,-beta}{,-bin}, librewolf: blah blah blah
+              workflows/eval: should be ignored
             "
                 .lines()
                 .map(|l| l.to_owned())

--- a/ofborg/src/tasks/githubcommentposter.rs
+++ b/ofborg/src/tasks/githubcommentposter.rs
@@ -106,7 +106,7 @@ fn job_to_check(job: &BuildJob, architecture: &str, timestamp: DateTime<Utc>) ->
     }
 
     CheckRunOptions {
-        name: format!("{} on {architecture}", all_attrs.join(", ")),
+        name: format!(".{architecture}: {}", all_attrs.join(", ")),
         actions: None,
         completed_at: None,
         started_at: Some(timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
@@ -175,7 +175,7 @@ fn result_to_check(result: &LegacyBuildResult, timestamp: DateTime<Utc>) -> Chec
     };
 
     CheckRunOptions {
-        name: format!("{} on {}", all_attrs.join(", "), result.system),
+        name: format!(".{}: {}", result.system, all_attrs.join(", ")),
         actions: None,
         completed_at: Some(timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
         started_at: None,
@@ -244,7 +244,7 @@ mod tests {
         assert_eq!(
             job_to_check(&job, "x86_64-linux", timestamp),
             CheckRunOptions {
-                name: "bar, foo on x86_64-linux".to_string(),
+                name: ".x86_64-linux: bar, foo".to_string(),
                 actions: None,
                 started_at: Some("2023-04-20T13:37:42Z".to_string()),
                 completed_at: None,
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "bar, foo on x86_64-linux".to_string(),
+                name: ".x86_64-linux: bar, foo".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -379,7 +379,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "foo on x86_64-linux".to_string(),
+                name: ".x86_64-linux: foo".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -458,7 +458,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "foo on x86_64-linux".to_string(),
+                name: ".x86_64-linux: foo".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -538,7 +538,7 @@ error: build of '/nix/store/l1limh50lx2cx45yb2gqpv7k8xl1mik2-gdb-8.1.drv' failed
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "(unknown attributes) on x86_64-linux".to_string(),
+                name: ".x86_64-linux: (unknown attributes)".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -616,7 +616,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "(unknown attributes) on x86_64-linux".to_string(),
+                name: ".x86_64-linux: (unknown attributes)".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -683,7 +683,7 @@ patching script interpreter paths in /nix/store/pcja75y9isdvgz5i00pkrpif9rxzxc29
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "not-attempted on x86_64-linux".to_string(),
+                name: ".x86_64-linux: not-attempted".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),
@@ -736,7 +736,7 @@ foo
         assert_eq!(
             result_to_check(&result, timestamp),
             CheckRunOptions {
-                name: "not-attempted on x86_64-linux".to_string(),
+                name: ".x86_64-linux: not-attempted".to_string(),
                 actions: None,
                 started_at: None,
                 completed_at: Some("2023-04-20T13:37:42Z".to_string()),


### PR DESCRIPTION
With long status entries with many packages, the system is cut off. Since the system is fixed length, it makes more sense to put it at the front. This allows to easily identify the relevant checks.

Also avoid posting a status check for everything with "/" in the prefix, because that's not a package to build anyway.

Resolves #283