### PR TITLE
Remove `2.status: work-in-progress` label support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ When opening a PR with multiple commits, ofborg creates a single build job for
 all detected packages. If multiple commits get pushed to a PR one-by-one, each
 detected package will get a separate build job.
 
-If the title of a PR begins with `WIP:`, contains `[WIP]` anywhere, or has the
-`2.status: work-in-progress` label, its packages are not built automatically.
+If the title of a PR begins with `WIP:` or contains `[WIP]` anywhere, its
+packages are not built automatically.
 **Note**: Marking a PR as a draft does not prevent automatic builds.
 
 ## Commands

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -485,29 +485,7 @@ pub fn update_labels(issueref: &hubcaps::issues::IssueRef, add: &[String], remov
 }
 
 fn issue_is_wip(issue: &hubcaps::issues::Issue) -> bool {
-    if issue.title.contains("[WIP]") {
-        return true;
-    }
-
-    if issue.title.starts_with("WIP:") {
-        return true;
-    }
-
-    issue.labels.iter().any(|label| indicates_wip(&label.name))
-}
-
-fn indicates_wip(text: &str) -> bool {
-    let text = text.to_lowercase();
-
-    if text.contains("work in progress") {
-        return true;
-    }
-
-    if text.contains("work-in-progress") {
-        return true;
-    }
-
-    false
+    return issue.title.starts_with("WIP:") || issue.title.contains("[WIP]");
 }
 
 /// Determine whether or not to use the "old" status prefix, `grahamcofborg`, or


### PR DESCRIPTION
This label is being removed, as discussed in https://github.com/NixOS/nixpkgs/issues/419944

Draft for now, until this is agreed upon in https://github.com/NixOS/nixpkgs/issues/419944

EDIT: label removed, so undrafted