### PR TITLE
Remove merge conflict label

### DIFF
--- a/ofborg/src/tasks/eval/mod.rs
+++ b/ofborg/src/tasks/eval/mod.rs
@@ -13,7 +13,6 @@ pub trait EvaluationStrategy {
 
     fn on_target_branch(&mut self, co: &Path, status: &mut CommitStatus) -> StepResult<()>;
     fn after_fetch(&mut self, co: &CachedProjectCo) -> StepResult<()>;
-    fn merge_conflict(&mut self);
     fn after_merge(&mut self, status: &mut CommitStatus) -> StepResult<()>;
     fn evaluation_checks(&self) -> Vec<EvalChecker>;
     fn all_evaluations_passed(

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -128,21 +128,7 @@ impl<'a> EvaluationStrategy for NixpkgsStrategy<'a> {
         Ok(())
     }
 
-    fn merge_conflict(&mut self) {
-        update_labels(
-            self.issue_ref,
-            &["2.status: merge conflict".to_owned()],
-            &[],
-        );
-    }
-
     fn after_merge(&mut self, status: &mut CommitStatus) -> StepResult<()> {
-        update_labels(
-            self.issue_ref,
-            &[],
-            &["2.status: merge conflict".to_owned()],
-        );
-
         status.set_with_description("Checking new out paths", hubcaps::statuses::State::Pending)?;
         self.check_outpaths_after()?;
 

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -355,8 +355,6 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
 
             info!("Failed to merge {}", job.pr.head_sha);
 
-            evaluation_strategy.merge_conflict();
-
             return Ok(self.actions().skip(job));
         }
 


### PR DESCRIPTION
This label is now managed by Nixpkgs CI. Technically it doesn't hurt to manage it via ofborg, too, but ofborg is *too quick* sometimes. The scheduled labeler in nixpkgs CI works with a bit of delay and thus doesn't temporarily label a PR conflicted while changing base branches and pushing again.

As discussed in https://github.com/NixOS/nixpkgs/pull/422906#issuecomment-3041481371.

cc @philiptaron