### PR TITLE
Remove apple_sdk references in darwin build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,16 +89,6 @@
               pkgs.rustPackages.clippy
             ];
 
-            buildInputs =
-              with pkgs;
-              lib.optionals pkgs.stdenv.isDarwin (
-                with pkgs;
-                [
-                  darwin.apple_sdk.frameworks.Security
-                  darwin.apple_sdk.frameworks.CoreFoundation
-                ]
-              );
-
             preBuild = ''
               cargo clippy
             '';


### PR DESCRIPTION
Accessing darwin.apple_sdk on nixpkgs-25.11 and newer causes an eval error

darwin.apple_sdk_11_0 has been removed as
it was a legacy compatibility stub; see
<https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions