### PR TITLE
improve labeling for musl libc and cross compilation items

### DIFF
--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -17,8 +17,8 @@ const TITLE_LABELS: [(&str, &str); 5] = [
     ("bsd", "6.topic: bsd"),
     ("darwin", "6.topic: darwin"),
     ("macos", "6.topic: darwin"),
-    ("cross", "6.topic: cross-compilation"),
-    ("musl", "6.topic: musl"),
+    ("cross|pkgsCross", "6.topic: cross-compilation"),
+    ("musl|pkgsMusl", "6.topic: musl"),
 ];
 
 fn label_from_title(title: &str) -> Vec<String> {
@@ -273,7 +273,15 @@ mod tests {
             vec![String::from("6.topic: cross-compilation")]
         );
         assert_eq!(
+            label_from_title("haskellPackages: fix some pkgsCross.ghcjs packages"),
+            vec![String::from("6.topic: cross-compilation")]
+        );
+        assert_eq!(
             label_from_title("pkg: fix musl"),
+            vec![String::from("6.topic: musl")]
+        );
+        assert_eq!(
+            label_from_title("pkgsMusl.attr-path: fix build"),
             vec![String::from("6.topic: musl")]
         );
     }

--- a/ofborg/src/tasks/eval/nixpkgs.rs
+++ b/ofborg/src/tasks/eval/nixpkgs.rs
@@ -13,11 +13,12 @@ use hubcaps::issues::IssueRef;
 use regex::Regex;
 use uuid::Uuid;
 
-const TITLE_LABELS: [(&str, &str); 4] = [
+const TITLE_LABELS: [(&str, &str); 5] = [
     ("bsd", "6.topic: bsd"),
     ("darwin", "6.topic: darwin"),
     ("macos", "6.topic: darwin"),
     ("cross", "6.topic: cross-compilation"),
+    ("musl", "6.topic: musl"),
 ];
 
 fn label_from_title(title: &str) -> Vec<String> {
@@ -270,6 +271,10 @@ mod tests {
         assert_eq!(
             label_from_title("pkg: fix cross-compilation"),
             vec![String::from("6.topic: cross-compilation")]
+        );
+        assert_eq!(
+            label_from_title("pkg: fix musl"),
+            vec![String::from("6.topic: musl")]
         );
     }
 }


### PR DESCRIPTION
better auto-labeling criteria for these labels:
- [musl](https://github.com/NixOS/nixpkgs/pulls?q=label%3A%226.topic%3A+musl%22+)
- [cross compilation](https://github.com/NixOS/nixpkgs/pulls?q=label%3A%226.topic%3A+cross-compilation%22+)