### PR TITLE
fix: Don't return info on dirs outside of logs_path

### DIFF
--- a/ofborg/src/bin/logapi.rs
+++ b/ofborg/src/bin/logapi.rs
@@ -26,7 +26,7 @@ struct LogResponse {
 
 #[derive(Clone)]
 struct LogApiConfig {
-    logs_path: String,
+    logs_path: PathBuf,
     serve_root: String,
 }
 
@@ -57,10 +57,13 @@ async fn handle_request(
     let Some(reqd) = uri.strip_prefix("/logs/").map(ToOwned::to_owned) else {
         return Ok(response(StatusCode::NOT_FOUND, "invalid uri"));
     };
-    let path: PathBuf = [&cfg.logs_path, &reqd].iter().collect();
+    let path: PathBuf = cfg.logs_path.join(&reqd);
     let Ok(path) = std::fs::canonicalize(&path) else {
         return Ok(response(StatusCode::NOT_FOUND, "absent"));
     };
+    if !path.starts_with(&cfg.logs_path) {
+        return Ok(response(StatusCode::NOT_FOUND, "invalid path"));
+    }
     let Ok(iter) = std::fs::read_dir(path) else {
         return Ok(response(StatusCode::NOT_FOUND, "non dir"));
     };
@@ -125,8 +128,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         panic!();
     };
 
+    let logs_path = std::fs::canonicalize(&cfg.logs_path)
+        .expect("logs_path does not exist or is not accessible");
+
     let api_cfg = Arc::new(LogApiConfig {
-        logs_path: cfg.logs_path,
+        logs_path,
         serve_root: cfg.serve_root,
     });
 


### PR DESCRIPTION
This PR fixes a minor security issue that leaks filenames under specific conditions. If you can access the logapi endpoint directly or if a reverse proxy isn't canonicalizing paths in requests, it's possible to leak filenames in any directory the ofborg user can access that doesn't contain other subdirectories.

Steps to reproduce (in the ofborg repo):
```
cat > conf << 'EOF'
{
  "log_api_config": {
    "listen": "0.0.0.0:8080",
    "logs_path": "/var/lib/"
  },
  "runner": {
      "identity": "logapi",
      "repos": [],
      "disable_trusted_users": true,
      "trusted_users": []
  },
  "checkout": {
      "root": "/tmp/ofborg-checkout"
  },
  "nix": {
      "system": "x86_64-linux",
      "remote": "daemon",
      "build_timeout_seconds": 3600,
      "initial_heap_size": "4g"
  }
}
EOF

nix-shell
cargo run --bin logapi -- conf

curl --path-as-is 127.0.0.1:8080/logs/../../etc/ssh
{"attempts":{"ssh_host_rsa_key":{"metadata":null,"result":null,"log_url":"https://logs.ofborg.org/logfile/../../etc/ssh/ssh_host_rsa_key"},"ssh_host_ed25519_key.pub":{"metadata":null,"result":null,"log_url":"https://logs.ofborg.org/logfile/../../etc/ssh/ssh_host_ed25519_key.pub"},"initrd_ssh_host_ed25519_key":{"metadata":null,"result":null,"log_url":"https://logs.ofborg.org/logfile/../../etc/ssh/initrd_ssh_host_ed25519_key"},"ssh_host_ed25519_key":{"metadata":null,"result":null,"log_url":"https://logs.ofborg.org/logfile/../../etc/ssh/ssh_host_ed25519_key"},"ssh_host_rsa_key.pub":{"metadata":null,"result":null,"log_url":"https://logs.ofborg.org/logfile/../../etc/ssh/ssh_host_rsa_key.pub"}}}
```

I've also added a check that `logs_path` exists since I ran into an issue with it while experimenting with this bug.

Edit: I've already synced with @mweinelt about opening this PR since it's not important enough to warrant an embargo.