### PR TITLE
flake: skip clippy on x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,16 +80,23 @@
         let
           pkgs = import nixpkgs { inherit system; };
 
+          # clippy fails to build on x86_64-darwin (nixpkgs missing
+          # -headerpad_max_install_names, cf. rustfmt fix in nixpkgs#369349).
+          # Skip the lint step there.
+          runClippy = !(pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isx86_64);
+
           pkg = pkgs.rustPlatform.buildRustPackage {
             name = "ofborg";
             src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
-            nativeBuildInputs = with pkgs; [
-              pkg-config
-              pkgs.rustPackages.clippy
-            ];
+            nativeBuildInputs =
+              with pkgs;
+              [
+                pkg-config
+              ]
+              ++ pkgs.lib.optional runClippy pkgs.rustPackages.clippy;
 
-            preBuild = ''
+            preBuild = pkgs.lib.optionalString runClippy ''
               cargo clippy
             '';
 


### PR DESCRIPTION
clippy currently fails to build on x86_64-darwin with nixpkgs nixos-25.11: install_name_tool runs out of headerpad during the fixup phase. The clippy derivation in nixpkgs is missing the -headerpad_max_install_names workaround that rustfmt already got in NixOS/nixpkgs#369349.

Since we run cargo clippy in preBuild, this breaks the whole ofborg package on x86_64-darwin. Skip the lint step on that platform until nixpkgs is fixed.

Found while merging ofborg-infrastructure into NixOS/infra (NixOS/infra#1009).