### PR TITLE
builds: schedule automatic jobs on relevant systems

### DIFF
--- a/ofborg/src/any-instantiable.nix
+++ b/ofborg/src/any-instantiable.nix
@@ -1,0 +1,47 @@
+{ system, attrsJSON, ... }:
+let
+  lib = import <ofborg-nixpkgs-pr/lib>;
+  source = import <ofborg-nixpkgs-pr>;
+  pkgs = if builtins.isFunction source then source { inherit system; } else source;
+  attrPaths = builtins.fromJSON attrsJSON;
+
+  lookupAttrPath = path: value:
+    if path == [ ] then
+      { found = true; inherit value; }
+    else
+      let
+        name = builtins.head path;
+      in
+      if builtins.isAttrs value && builtins.hasAttr name value then
+        lookupAttrPath (builtins.tail path) (builtins.getAttr name value)
+      else
+        { found = false; };
+
+  isDerivation = value:
+    builtins.isAttrs value && value.type or null == "derivation";
+
+  instantiateValue = value:
+    if isDerivation value then
+      builtins.deepSeq value.drvPath true
+    else if builtins.isAttrs value then
+      builtins.deepSeq (map instantiateValue (builtins.attrValues value)) true
+    else if builtins.isList value then
+      builtins.deepSeq (map instantiateValue value) true
+    else
+      false;
+
+  isInstantiable = path:
+    let
+      attempted = builtins.tryEval (
+        let
+          lookup = lookupAttrPath path pkgs;
+        in
+        lookup.found && instantiateValue lookup.value
+      );
+    in
+    attempted.success && attempted.value;
+in
+if builtins.elem system lib.systems.flakeExposed then
+  builtins.seq pkgs (builtins.any isInstantiable attrPaths)
+else
+  false

--- a/ofborg/src/bin/build-faker.rs
+++ b/ofborg/src/bin/build-faker.rs
@@ -1,4 +1,5 @@
 use lapin::message::Delivery;
+use lapin::options::ConfirmSelectOptions;
 use std::env;
 use std::error::Error;
 
@@ -18,6 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let conn = easylapin::from_config(&cfg.builder.unwrap().rabbitmq).await?;
     let chan = conn.create_channel().await?;
+    chan.confirm_select(ConfirmSelectOptions::default()).await?;
 
     let repo_msg = Repo {
         clone_url: "https://github.com/nixos/ofborg.git".to_owned(),

--- a/ofborg/src/bin/github-comment-poster.rs
+++ b/ofborg/src/bin/github-comment-poster.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     })
     .await?;
 
-    let handle = easylapin::WorkerChannel(chan)
+    let handle = easylapin::NotifyChannel(chan)
         .consume(
             tasks::githubcommentposter::GitHubCommentPoster::new(cfg.github_app_vendingmachine()),
             easyamqp::ConsumeConfig {

--- a/ofborg/src/bin/mass-rebuilder.rs
+++ b/ofborg/src/bin/mass-rebuilder.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             tasks::evaluate::EvaluationWorker::new(
                 cloner,
                 cfg.github_app_vendingmachine(),
+                cfg.nix(),
                 cfg.acl(),
                 cfg.runner.identity.clone(),
                 events,

--- a/ofborg/src/easylapin.rs
+++ b/ofborg/src/easylapin.rs
@@ -13,10 +13,12 @@ use crate::worker::{Action, SimpleWorker};
 use lapin::message::Delivery;
 use lapin::options::{
     BasicAckOptions, BasicConsumeOptions, BasicNackOptions, BasicPublishOptions, BasicQosOptions,
-    ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions,
+    ConfirmSelectOptions, ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions,
 };
 use lapin::types::FieldTable;
-use lapin::{BasicProperties, Channel, Connection, ConnectionProperties, ExchangeKind};
+use lapin::{
+    BasicProperties, Channel, Confirmation, Connection, ConnectionProperties, ExchangeKind,
+};
 use tokio_stream::StreamExt;
 use tracing::{debug, trace};
 
@@ -88,6 +90,7 @@ impl<'a, W: SimpleWorker + 'a> ConsumerExt<'a, W> for Channel {
         mut worker: W,
         config: ConsumeConfig,
     ) -> Result<Self::Handle, Self::Error> {
+        self.confirm_select(ConfirmSelectOptions::default()).await?;
         let mut consumer = self
             .basic_consume(
                 config.queue.into(),
@@ -163,6 +166,9 @@ impl<'a, W: SimpleNotifyWorker + 'a + Send> ConsumerExt<'a, W> for NotifyChannel
     type Handle = Pin<Box<dyn Future<Output = ()> + 'a + Send>>;
 
     async fn consume(self, worker: W, config: ConsumeConfig) -> Result<Self::Handle, Self::Error> {
+        self.0
+            .confirm_select(ConfirmSelectOptions::default())
+            .await?;
         self.0.basic_qos(1, BasicQosOptions::default()).await?;
 
         let mut consumer = self
@@ -235,17 +241,50 @@ async fn action_deliver(
                 props = props.with_content_type(s.into());
             }
 
-            let _confirmaton = chan
+            let confirmation = chan
                 .basic_publish(
                     exch.into(),
                     key.into(),
-                    BasicPublishOptions::default(),
+                    BasicPublishOptions {
+                        mandatory: msg.mandatory,
+                        immediate: msg.immediate,
+                    },
                     &msg.content,
                     props,
                 )
                 .await?
                 .await?;
-            Ok(())
+
+            ensure_publisher_confirmation(confirmation)
         }
+    }
+}
+
+fn ensure_publisher_confirmation(confirmation: Confirmation) -> Result<(), lapin::Error> {
+    match confirmation {
+        Confirmation::Ack(None) => Ok(()),
+        Confirmation::Ack(Some(returned)) => Err(std::io::Error::other(format!(
+            "message was returned as unroutable: {returned:?}"
+        ))
+        .into()),
+        Confirmation::Nack(returned) => Err(std::io::Error::other(format!(
+            "message was rejected by the broker: {returned:?}"
+        ))
+        .into()),
+        Confirmation::NotRequested => {
+            Err(std::io::Error::other("publisher confirmation was not requested").into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publisher_confirmations_must_ack_without_returning_the_message() {
+        assert!(ensure_publisher_confirmation(Confirmation::Ack(None)).is_ok());
+        assert!(ensure_publisher_confirmation(Confirmation::Nack(None)).is_err());
+        assert!(ensure_publisher_confirmation(Confirmation::NotRequested).is_err());
     }
 }

--- a/ofborg/src/message/buildjob.rs
+++ b/ofborg/src/message/buildjob.rs
@@ -1,7 +1,7 @@
 use crate::commentparser::Subset;
 use crate::message::{Pr, Repo};
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct BuildJob {
     pub repo: Repo,
     pub pr: Pr,
@@ -16,6 +16,12 @@ pub struct BuildJob {
 pub struct QueuedBuildJobs {
     pub job: BuildJob,
     pub architectures: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct AutomaticBuildJobs {
+    pub builds: Vec<QueuedBuildJobs>,
+    pub evaluation_status: String,
 }
 
 pub type ExchangeQueue = (Option<Exchange>, Option<RoutingKey>);

--- a/ofborg/src/message/evaluationjob.rs
+++ b/ofborg/src/message/evaluationjob.rs
@@ -11,6 +11,17 @@ pub struct EvaluationJob {
     pub pr: Pr,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct EvaluationStatus {
+    pub repo: Repo,
+    pub pr: Pr,
+    pub context: String,
+    pub description: String,
+    pub success: bool,
+    #[serde(default)]
+    pub attempts: u8,
+}
+
 pub struct Actions {}
 
 impl Actions {

--- a/ofborg/src/nix.rs
+++ b/ofborg/src/nix.rs
@@ -194,6 +194,32 @@ impl Nix {
         self.run(command, true)
     }
 
+    pub fn any_attr_instantiable(
+        &self,
+        nixpkgs: &Path,
+        attrs: &[String],
+    ) -> Result<bool, Vec<String>> {
+        let attr_paths: Vec<Vec<&str>> =
+            attrs.iter().map(|attr| attr.split('.').collect()).collect();
+        let attrs_json = serde_json::to_string(&attr_paths)
+            .expect("serializing attribute paths should not fail");
+        let mut argstrs = HashMap::new();
+        argstrs.insert("attrsJSON", attrs_json.as_str());
+
+        let command = self.safely_evaluate_expr_cmd(
+            nixpkgs,
+            include_str!("any-instantiable.nix"),
+            argstrs,
+            &[],
+        );
+
+        match self.run(command, true) {
+            Ok(output) => serde_json::from_reader(output)
+                .map_err(|err| vec![format!("failed to parse Nix evaluation result: {err}")]),
+            Err(output) => Err(lines_from_file(output)),
+        }
+    }
+
     pub fn safely_evaluate_expr_cmd(
         &self,
         nixpkgs: &Path,
@@ -451,6 +477,12 @@ mod tests {
     fn individual_eval_path() -> PathBuf {
         let mut cwd = env::current_dir().unwrap();
         cwd.push(Path::new("./test-srcs/eval-mixed-failure"));
+        cwd
+    }
+
+    fn instantiable_path() -> PathBuf {
+        let mut cwd = env::current_dir().unwrap();
+        cwd.push(Path::new("./test-srcs/instantiable"));
         cwd
     }
 
@@ -716,6 +748,46 @@ mod tests {
                 "./nixos/release.nix",
                 "--arg nixpkgs { outPath=./.; revCount=999999; shortRev=\"ofborg\"; rev=\"0000000000000000000000000000000000000000\"; }",
             ],
+        );
+    }
+
+    #[test]
+    fn any_attr_instantiable() {
+        let nix = nix();
+        let path = instantiable_path();
+
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["package".to_owned()]),
+            Ok(true)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["missing".to_owned()]),
+            Ok(false)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["unavailable".to_owned()]),
+            Ok(false)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["scalar".to_owned()]),
+            Ok(false)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["missing".to_owned(), "tests".to_owned()]),
+            Ok(true)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["tests.nested".to_owned()]),
+            Ok(true)
+        );
+        assert_eq!(
+            nix.any_attr_instantiable(path.as_path(), &["empty".to_owned()]),
+            Ok(true)
+        );
+        assert_eq!(
+            nix.with_system("unsupported-system".to_owned())
+                .any_attr_instantiable(path.as_path(), &["package".to_owned()]),
+            Ok(false)
         );
     }
 

--- a/ofborg/src/tasks/evaluate.rs
+++ b/ofborg/src/tasks/evaluate.rs
@@ -4,6 +4,7 @@ use crate::checkout;
 use crate::commitstatus::{CommitStatus, CommitStatusError};
 use crate::config::GithubAppVendingMachine;
 use crate::message::{buildjob, evaluationjob};
+use crate::nix;
 use crate::stats::{self, Event};
 use crate::systems;
 use crate::tasks::eval;
@@ -20,6 +21,7 @@ use tracing::{debug_span, error, info, warn};
 pub struct EvaluationWorker<E> {
     cloner: checkout::CachedCloner,
     github_vend: tokio::sync::RwLock<GithubAppVendingMachine>,
+    nix: nix::Nix,
     acl: Acl,
     identity: String,
     events: E,
@@ -29,6 +31,7 @@ impl<E: stats::SysEvents> EvaluationWorker<E> {
     pub fn new(
         cloner: checkout::CachedCloner,
         github_vend: GithubAppVendingMachine,
+        nix: nix::Nix,
         acl: Acl,
         identity: String,
         events: E,
@@ -36,6 +39,7 @@ impl<E: stats::SysEvents> EvaluationWorker<E> {
         EvaluationWorker {
             cloner,
             github_vend: tokio::sync::RwLock::new(github_vend),
+            nix,
             acl,
             identity,
             events,
@@ -82,6 +86,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for EvaluationWorker<E>
 
         OneEval::new(
             github_client,
+            &self.nix,
             &self.acl,
             &mut self.events,
             &self.identity,
@@ -96,6 +101,7 @@ impl<E: stats::SysEvents + 'static> worker::SimpleWorker for EvaluationWorker<E>
 struct OneEval<'a, E> {
     client_app: &'a hubcaps::Github,
     repo: hubcaps::repositories::Repository,
+    nix: &'a nix::Nix,
     acl: &'a Acl,
     events: &'a mut E,
     identity: &'a str,
@@ -107,6 +113,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
     #[allow(clippy::too_many_arguments)]
     fn new(
         client_app: &'a hubcaps::Github,
+        nix: &'a nix::Nix,
         acl: &'a Acl,
         events: &'a mut E,
         identity: &'a str,
@@ -117,6 +124,7 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
         OneEval {
             client_app,
             repo,
+            nix,
             acl,
             events,
             identity,
@@ -439,11 +447,20 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
                 .all_evaluations_passed(&mut overall_status)
                 .await?;
 
-            response.extend(schedule_builds(complete.builds, auto_schedule_build_archs));
+            let builds = classify_builds(
+                self.nix,
+                Path::new(&refpath),
+                complete.builds,
+                auto_schedule_build_archs,
+            )?;
 
-            overall_status
-                .set_with_description("^.^!", hubcaps::statuses::State::Success)
-                .await?;
+            if builds.is_empty() {
+                overall_status
+                    .set_with_description("^.^!", hubcaps::statuses::State::Success)
+                    .await?;
+            } else {
+                response.extend(schedule_builds(builds, format!("{prefix}-eval")));
+            }
         } else {
             overall_status
                 .set_with_description("Complete, with errors", hubcaps::statuses::State::Failure)
@@ -457,36 +474,78 @@ impl<'a, E: stats::SysEvents + 'static> OneEval<'a, E> {
     }
 }
 
-fn schedule_builds(
+struct ScheduledBuild {
+    job: buildjob::BuildJob,
+    architectures: Vec<systems::System>,
+}
+
+fn classify_builds(
+    nix: &nix::Nix,
+    nixpkgs: &Path,
     builds: Vec<buildjob::BuildJob>,
-    auto_schedule_build_archs: Vec<systems::System>,
-) -> Vec<worker::Action> {
-    let mut response = vec![];
-    info!(
-        "Scheduling build jobs {:?} on arches {:?}",
-        builds, auto_schedule_build_archs
-    );
-    for buildjob in builds {
-        for arch in auto_schedule_build_archs.iter() {
-            let (exchange, routingkey) = arch.as_build_destination();
-            response.push(worker::publish_serde_action(
-                exchange, routingkey, &buildjob,
-            ));
+    architectures: Vec<systems::System>,
+) -> Result<Vec<ScheduledBuild>, eval::Error> {
+    let mut scheduled = vec![];
+
+    for job in builds {
+        let mut relevant_architectures = vec![];
+
+        for architecture in &architectures {
+            match nix
+                .with_system(architecture.to_string())
+                .any_attr_instantiable(nixpkgs, &job.attrs)
+            {
+                Ok(true) => relevant_architectures.push(architecture.clone()),
+                Ok(false) => info!(
+                    system = %architecture,
+                    attrs = ?job.attrs,
+                    "Skipping automatic build without instantiable attributes"
+                ),
+                Err(errors) => {
+                    error!(
+                        system = %architecture,
+                        attrs = ?job.attrs,
+                        errors = ?errors,
+                        "Failed to determine automatic build relevance"
+                    );
+                    return Err(eval::Error::Fail(format!(
+                        "Failed to determine build relevance on {architecture}"
+                    )));
+                }
+            }
         }
-        response.push(worker::publish_serde_action(
-            Some("build-results".to_string()),
-            None,
-            &buildjob::QueuedBuildJobs {
-                job: buildjob,
-                architectures: auto_schedule_build_archs
-                    .iter()
-                    .map(|arch| arch.to_string())
-                    .collect(),
-            },
-        ));
+
+        if !relevant_architectures.is_empty() {
+            scheduled.push(ScheduledBuild {
+                job,
+                architectures: relevant_architectures,
+            });
+        }
     }
 
-    response
+    Ok(scheduled)
+}
+
+fn schedule_builds(builds: Vec<ScheduledBuild>, evaluation_status: String) -> Vec<worker::Action> {
+    let queued_builds = builds
+        .iter()
+        .map(|build| buildjob::QueuedBuildJobs {
+            job: build.job.clone(),
+            architectures: build
+                .architectures
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        })
+        .collect();
+    vec![worker::publish_serde_action_mandatory(
+        Some("build-results".to_owned()),
+        None,
+        &buildjob::AutomaticBuildJobs {
+            builds: queued_builds,
+            evaluation_status,
+        },
+    )]
 }
 
 pub async fn update_labels(
@@ -567,5 +626,117 @@ impl From<eval::Error> for EvalWorkerError {
 impl From<CommitStatusError> for EvalWorkerError {
     fn from(e: CommitStatusError) -> EvalWorkerError {
         EvalWorkerError::CommitStatusWrite(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commentparser::Subset;
+    use crate::message::{Pr, Repo};
+    use std::env;
+    use std::path::PathBuf;
+
+    fn nix() -> nix::Nix {
+        nix::Nix::new(
+            "x86_64-linux".to_owned(),
+            env::var("NIX_REMOTE").unwrap_or_default(),
+            1800,
+            None,
+        )
+    }
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("test-srcs")
+            .join(name)
+    }
+
+    fn build(attrs: &[&str]) -> buildjob::BuildJob {
+        buildjob::BuildJob::new(
+            Repo {
+                clone_url: "https://github.com/NixOS/nixpkgs.git".to_owned(),
+                full_name: "NixOS/nixpkgs".to_owned(),
+                owner: "NixOS".to_owned(),
+                name: "nixpkgs".to_owned(),
+            },
+            Pr {
+                head_sha: "abc123".to_owned(),
+                number: 42,
+                target_branch: Some("master".to_owned()),
+            },
+            Subset::Nixpkgs,
+            attrs.iter().map(|attr| (*attr).to_owned()).collect(),
+            None,
+            None,
+            "request-id".to_owned(),
+        )
+    }
+
+    #[test]
+    fn automatic_builds_only_target_relevant_systems() {
+        let scheduled = match classify_builds(
+            &nix(),
+            &fixture("instantiable"),
+            vec![build(&["linux-only"])],
+            systems::System::all_known_systems().to_vec(),
+        ) {
+            Ok(scheduled) => scheduled,
+            Err(_) => panic!("classification should succeed"),
+        };
+
+        assert_eq!(scheduled.len(), 1);
+        assert_eq!(scheduled[0].architectures.len(), 2);
+        assert_eq!(
+            scheduled[0]
+                .architectures
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["x86_64-linux", "aarch64-linux"]
+        );
+
+        let actions = schedule_builds(scheduled, "ofborg-eval".to_owned());
+        assert_eq!(actions.len(), 1);
+        let worker::Action::Publish(queued_message) = &actions[0] else {
+            panic!("automatic build plan should be published");
+        };
+        assert_eq!(queued_message.exchange, Some("build-results".to_owned()));
+        assert!(queued_message.mandatory);
+        let queued: buildjob::AutomaticBuildJobs =
+            serde_json::from_slice(&queued_message.content).unwrap();
+        assert_eq!(queued.evaluation_status, "ofborg-eval");
+        assert_eq!(queued.builds.len(), 1);
+        assert_eq!(
+            queued.builds[0].architectures,
+            vec!["x86_64-linux", "aarch64-linux"]
+        );
+    }
+
+    #[test]
+    fn automatic_builds_are_not_scheduled_without_relevant_systems() {
+        let scheduled = match classify_builds(
+            &nix(),
+            &fixture("instantiable"),
+            vec![build(&["missing", "unavailable"])],
+            systems::System::all_known_systems().to_vec(),
+        ) {
+            Ok(scheduled) => scheduled,
+            Err(_) => panic!("classification should succeed"),
+        };
+
+        assert!(scheduled.is_empty());
+    }
+
+    #[test]
+    fn automatic_build_classification_errors_are_not_treated_as_irrelevant() {
+        let result = classify_builds(
+            &nix(),
+            &fixture("instantiable-broken"),
+            vec![build(&["package"])],
+            vec![systems::System::X8664Linux],
+        );
+
+        assert!(matches!(result, Err(eval::Error::Fail(_))));
     }
 }

--- a/ofborg/src/tasks/githubcommentfilter.rs
+++ b/ofborg/src/tasks/githubcommentfilter.rs
@@ -131,16 +131,11 @@ impl worker::SimpleWorker for GitHubCommentWorker {
                             Uuid::new_v4().to_string(),
                         );
 
-                        for arch in build_destinations.iter() {
-                            let (exchange, routingkey) = arch.as_build_destination();
-                            response.push(worker::publish_serde_action(exchange, routingkey, &msg));
-                        }
-
-                        response.push(worker::publish_serde_action(
+                        response.push(worker::publish_serde_action_mandatory(
                             Some("build-results".to_string()),
                             None,
                             &buildjob::QueuedBuildJobs {
-                                job: msg,
+                                job: msg.clone(),
                                 architectures: build_destinations
                                     .iter()
                                     .cloned()
@@ -148,6 +143,13 @@ impl worker::SimpleWorker for GitHubCommentWorker {
                                     .collect(),
                             },
                         ));
+
+                        for arch in build_destinations.iter() {
+                            let (exchange, routingkey) = arch.as_build_destination();
+                            response.push(worker::publish_serde_action_mandatory(
+                                exchange, routingkey, &msg,
+                            ));
+                        }
                     }
                     commentparser::Instruction::Eval => {
                         let msg = evaluationjob::EvaluationJob {

--- a/ofborg/src/tasks/githubcommentposter.rs
+++ b/ofborg/src/tasks/githubcommentposter.rs
@@ -1,61 +1,169 @@
+use crate::commitstatus::{CommitStatus, CommitStatusError};
 use crate::config::GithubAppVendingMachine;
 use crate::message::Repo;
-use crate::message::buildjob::{BuildJob, QueuedBuildJobs};
+use crate::message::buildjob::{AutomaticBuildJobs, BuildJob, QueuedBuildJobs};
 use crate::message::buildresult::{BuildResult, BuildStatus, LegacyBuildResult};
+use crate::message::evaluationjob::EvaluationStatus;
+use crate::notifyworker::{self, NotificationReceiver};
 use crate::worker;
 
 use chrono::{DateTime, Utc};
 use hubcaps::checks::{CheckRunOptions, CheckRunState, Conclusion, Output};
+use std::sync::Arc;
 use tracing::{debug, debug_span, info, warn};
 
 pub struct GitHubCommentPoster {
-    github_vend: GithubAppVendingMachine,
+    github_vend: tokio::sync::Mutex<GithubAppVendingMachine>,
 }
 
 impl GitHubCommentPoster {
     pub fn new(github_vend: GithubAppVendingMachine) -> GitHubCommentPoster {
-        GitHubCommentPoster { github_vend }
+        GitHubCommentPoster {
+            github_vend: tokio::sync::Mutex::new(github_vend),
+        }
+    }
+
+    async fn finish_evaluation(
+        &self,
+        evaluation: &EvaluationStatus,
+        notifier: Arc<dyn NotificationReceiver + Send + Sync>,
+    ) {
+        let repository = {
+            let mut github_vend = self.github_vend.lock().await;
+            github_vend
+                .for_repo(&evaluation.repo.owner, &evaluation.repo.name)
+                .await
+                .unwrap()
+                .repo(evaluation.repo.owner.clone(), evaluation.repo.name.clone())
+        };
+        let mut status = CommitStatus::new(
+            repository.statuses(),
+            evaluation.pr.head_sha.clone(),
+            evaluation.context.clone(),
+            evaluation.description.clone(),
+            None,
+        );
+        let state = if evaluation.success {
+            hubcaps::statuses::State::Success
+        } else {
+            hubcaps::statuses::State::Failure
+        };
+
+        match status
+            .set_with_description(&evaluation.description, state)
+            .await
+        {
+            Ok(()) => notifier.tell(worker::Action::Ack).await,
+            Err(CommitStatusError::MissingSha(err)) => {
+                warn!("Evaluation commit disappeared: {:?}", err);
+                notifier.tell(worker::Action::Ack).await;
+            }
+            Err(err) if evaluation.attempts < 5 => {
+                warn!(
+                    attempt = evaluation.attempts + 1,
+                    "Failed to complete evaluation status, retrying: {:?}", err
+                );
+                let mut retry = evaluation.clone();
+                retry.attempts += 1;
+                notifier
+                    .tell(worker::publish_serde_action_mandatory(
+                        Some("build-results".to_owned()),
+                        None,
+                        &retry,
+                    ))
+                    .await;
+                notifier.tell(worker::Action::Ack).await;
+            }
+            Err(err) => {
+                warn!("Failed to complete evaluation status: {:?}", err);
+                notifier.tell(worker::Action::Ack).await;
+            }
+        }
     }
 }
 
 pub enum PostableEvent {
+    AutomaticBuildsQueued(AutomaticBuildJobs),
     BuildQueued(QueuedBuildJobs),
     BuildFinished(BuildResult),
+    EvaluationStatus(EvaluationStatus),
 }
 
 impl PostableEvent {
     fn from(bytes: &[u8]) -> Result<PostableEvent, String> {
-        match serde_json::from_slice::<QueuedBuildJobs>(bytes) {
-            Ok(e) => Ok(PostableEvent::BuildQueued(e)),
-            Err(_) => match serde_json::from_slice::<BuildResult>(bytes) {
-                Ok(e) => Ok(PostableEvent::BuildFinished(e)),
-                Err(e) => Err(format!(
-                    "Failed to deserialize PostableEvent: {:?}, err: {:}",
-                    String::from_utf8_lossy(bytes),
-                    e
-                )),
+        match serde_json::from_slice::<AutomaticBuildJobs>(bytes) {
+            Ok(e) if !e.builds.is_empty() => Ok(PostableEvent::AutomaticBuildsQueued(e)),
+            Ok(_) => Err("Automatic build event contains no builds".to_owned()),
+            Err(_) => match serde_json::from_slice::<QueuedBuildJobs>(bytes) {
+                Ok(e) => Ok(PostableEvent::BuildQueued(e)),
+                Err(_) => match serde_json::from_slice::<BuildResult>(bytes) {
+                    Ok(e) => Ok(PostableEvent::BuildFinished(e)),
+                    Err(_) => match serde_json::from_slice::<EvaluationStatus>(bytes) {
+                        Ok(e) => Ok(PostableEvent::EvaluationStatus(e)),
+                        Err(e) => Err(format!(
+                            "Failed to deserialize PostableEvent: {:?}, err: {:}",
+                            String::from_utf8_lossy(bytes),
+                            e
+                        )),
+                    },
+                },
             },
         }
     }
 }
 
-impl worker::SimpleWorker for GitHubCommentPoster {
+fn automatic_build_actions(builds: &AutomaticBuildJobs) -> worker::Actions {
+    builds
+        .builds
+        .iter()
+        .flat_map(|queued_job| {
+            queued_job.architectures.iter().map(|architecture| {
+                worker::publish_serde_action_mandatory(
+                    None,
+                    Some(format!("build-inputs-{architecture}")),
+                    &queued_job.job,
+                )
+            })
+        })
+        .collect()
+}
+
+#[async_trait::async_trait]
+impl notifyworker::SimpleNotifyWorker for GitHubCommentPoster {
     type J = PostableEvent;
 
-    async fn msg_to_job(
-        &mut self,
-        _: &str,
-        _: &Option<String>,
-        body: &[u8],
-    ) -> Result<Self::J, String> {
+    fn msg_to_job(&self, _: &str, _: &Option<String>, body: &[u8]) -> Result<Self::J, String> {
         PostableEvent::from(body)
     }
 
-    async fn consumer(&mut self, job: &PostableEvent) -> worker::Actions {
+    async fn consumer(
+        &self,
+        job: PostableEvent,
+        notifier: Arc<dyn NotificationReceiver + Send + Sync>,
+    ) {
+        if let PostableEvent::EvaluationStatus(evaluation) = &job {
+            self.finish_evaluation(evaluation, notifier).await;
+            return;
+        }
+
         let mut checks: Vec<CheckRunOptions> = vec![];
+        let mut evaluation_status = None;
         let repo: Repo;
 
-        let pr = match job {
+        let pr = match &job {
+            PostableEvent::AutomaticBuildsQueued(automatic_builds) => {
+                let first_build = &automatic_builds.builds[0];
+                repo = first_build.job.repo.clone();
+                evaluation_status = Some(automatic_builds.evaluation_status.clone());
+
+                for queued_job in &automatic_builds.builds {
+                    for architecture in &queued_job.architectures {
+                        checks.push(job_to_check(&queued_job.job, architecture, Utc::now()));
+                    }
+                }
+
+                first_build.job.pr.to_owned()
+            }
             PostableEvent::BuildQueued(queued_job) => {
                 repo = queued_job.job.repo.clone();
                 for architecture in queued_job.architectures.iter() {
@@ -69,10 +177,27 @@ impl worker::SimpleWorker for GitHubCommentPoster {
                 checks.push(result_to_check(&result, Utc::now()));
                 finished_job.pr()
             }
+            PostableEvent::EvaluationStatus(_) => unreachable!(),
         };
 
         let span = debug_span!("job", pr = ?pr.number);
         let _enter = span.enter();
+
+        if let PostableEvent::AutomaticBuildsQueued(automatic_builds) = &job {
+            for action in automatic_build_actions(automatic_builds) {
+                notifier.tell(action).await;
+            }
+        }
+
+        let repository = {
+            let mut github_vend = self.github_vend.lock().await;
+            github_vend
+                .for_repo(&repo.owner, &repo.name)
+                .await
+                .unwrap()
+                .repo(repo.owner.clone(), repo.name.clone())
+        };
+        let mut checks_succeeded = true;
 
         for check in checks {
             info!(
@@ -83,23 +208,39 @@ impl worker::SimpleWorker for GitHubCommentPoster {
             );
             debug!("{:?}", check);
 
-            let check_create_attempt = self
-                .github_vend
-                .for_repo(&repo.owner, &repo.name)
-                .await
-                .unwrap()
-                .repo(repo.owner.clone(), repo.name.clone())
-                .checkruns()
-                .create(&check)
-                .await;
-
-            match check_create_attempt {
+            match repository.checkruns().create(&check).await {
                 Ok(_) => info!("Successfully sent."),
-                Err(err) => warn!("Failed to send check {:?}", err),
+                Err(err) => {
+                    checks_succeeded = false;
+                    warn!("Failed to send check {:?}", err);
+                }
             }
         }
 
-        vec![worker::Action::Ack]
+        if let Some(context) = evaluation_status {
+            let (description, success) = if checks_succeeded {
+                ("^.^!", true)
+            } else {
+                ("Failed to create automatic build checks", false)
+            };
+            let evaluation = EvaluationStatus {
+                repo,
+                pr,
+                context,
+                description: description.to_owned(),
+                success,
+                attempts: 0,
+            };
+            notifier
+                .tell(worker::publish_serde_action_mandatory(
+                    Some("build-results".to_owned()),
+                    None,
+                    &evaluation,
+                ))
+                .await;
+        }
+
+        notifier.tell(worker::Action::Ack).await;
     }
 }
 
@@ -245,6 +386,50 @@ mod tests {
             request_id: "bogus-request-id".to_owned(),
             attrs: vec!["foo".to_owned(), "bar".to_owned()],
         };
+
+        let automatic_event = AutomaticBuildJobs {
+            builds: vec![QueuedBuildJobs {
+                job: job.clone(),
+                architectures: vec!["x86_64-linux".to_owned(), "aarch64-linux".to_owned()],
+            }],
+            evaluation_status: "ofborg-eval".to_owned(),
+        };
+        let serialized = serde_json::to_vec(&automatic_event).unwrap();
+        assert!(matches!(
+            PostableEvent::from(&serialized),
+            Ok(PostableEvent::AutomaticBuildsQueued(_))
+        ));
+        let actions = automatic_build_actions(&automatic_event);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions
+                .iter()
+                .map(|action| match action {
+                    worker::Action::Publish(message) => {
+                        assert!(message.mandatory);
+                        message.routing_key.clone()
+                    }
+                    _ => panic!("automatic build should be published"),
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                Some("build-inputs-x86_64-linux".to_owned()),
+                Some("build-inputs-aarch64-linux".to_owned())
+            ]
+        );
+
+        let evaluation = EvaluationStatus {
+            repo: job.repo.clone(),
+            pr: job.pr.clone(),
+            context: "ofborg-eval".to_owned(),
+            description: "^.^!".to_owned(),
+            success: true,
+            attempts: 0,
+        };
+        assert!(matches!(
+            PostableEvent::from(&serde_json::to_vec(&evaluation).unwrap()),
+            Ok(PostableEvent::EvaluationStatus(_))
+        ));
 
         let timestamp = Utc.with_ymd_and_hms(2023, 4, 20, 13, 37, 42).unwrap();
         assert_eq!(

--- a/ofborg/src/worker.rs
+++ b/ofborg/src/worker.rs
@@ -29,10 +29,27 @@ pub fn publish_serde_action<T: Serialize + ?Sized>(
     routing_key: Option<String>,
     msg: &T,
 ) -> Action {
+    publish_serde_action_with_options(exchange, routing_key, msg, false)
+}
+
+pub fn publish_serde_action_mandatory<T: Serialize + ?Sized>(
+    exchange: Option<String>,
+    routing_key: Option<String>,
+    msg: &T,
+) -> Action {
+    publish_serde_action_with_options(exchange, routing_key, msg, true)
+}
+
+fn publish_serde_action_with_options<T: Serialize + ?Sized>(
+    exchange: Option<String>,
+    routing_key: Option<String>,
+    msg: &T,
+    mandatory: bool,
+) -> Action {
     Action::Publish(Arc::new(QueueMsg {
         exchange,
         routing_key,
-        mandatory: false,
+        mandatory,
         immediate: false,
         content_type: Some("application/json".to_owned()),
         content: serde_json::to_string(&msg).unwrap().into_bytes(),

--- a/ofborg/test-srcs/instantiable-broken/default.nix
+++ b/ofborg/test-srcs/instantiable-broken/default.nix
@@ -1,0 +1,2 @@
+{ ... }:
+throw "top-level evaluation failed"

--- a/ofborg/test-srcs/instantiable-broken/lib/default.nix
+++ b/ofborg/test-srcs/instantiable-broken/lib/default.nix
@@ -1,0 +1,3 @@
+{
+  systems.flakeExposed = [ "x86_64-linux" ];
+}

--- a/ofborg/test-srcs/instantiable/default.nix
+++ b/ofborg/test-srcs/instantiable/default.nix
@@ -1,0 +1,34 @@
+{ system, ... }:
+{
+  package = derivation {
+    name = "package";
+    inherit system;
+    builder = "/bin/sh";
+    args = [ ];
+  };
+
+  unavailable = throw "not available on ${system}";
+  scalar = 42;
+
+  linux-only =
+    if builtins.match ".*-linux" system != null then
+      derivation {
+        name = "linux-only";
+        inherit system;
+        builder = "/bin/sh";
+        args = [ ];
+      }
+    else
+      throw "not available on ${system}";
+
+  tests = {
+    nested = derivation {
+      name = "nested-test";
+      inherit system;
+      builder = "/bin/sh";
+      args = [ ];
+    };
+  };
+
+  empty = { };
+}

--- a/ofborg/test-srcs/instantiable/lib/default.nix
+++ b/ofborg/test-srcs/instantiable/lib/default.nix
@@ -1,0 +1,8 @@
+{
+  systems.flakeExposed = [
+    "x86_64-linux"
+    "aarch64-linux"
+    "x86_64-darwin"
+    "aarch64-darwin"
+  ];
+}


### PR DESCRIPTION
## Summary

- classify automatically selected attributes once per configured system before scheduling builds
- create build jobs and queued checks only for systems where at least one attribute instantiates
- keep the evaluation status pending until the durable build plan has routed every job and created its checks
- verify RabbitMQ publisher confirmations and reject unroutable mandatory messages

## Motivation

Automatic builds are currently scheduled for every permitted architecture before a builder determines whether any selected attribute can instantiate there. On architectures without an applicable package, this can leave a queued check that cannot produce a useful build result when no worker consumes the job.

The evaluator now performs one batched, restricted Nix evaluation per target system. Unsupported systems are omitted; supported Darwin systems are still scheduled normally. Explicit `@ofborg build` and `@ofborg test` requests retain their queued feedback.

The build plan is handed to the GitHub comment poster as a durable message. The poster confirms that all jobs were routed, creates their queued checks, and only then completes the evaluation status, avoiding a temporarily green commit. Status finalization retries use a separate idempotent event so they do not republish builds.

Fixes #352.
Fixes #691.

Related: NixOS/nixpkgs#413633.

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (83 tests)
- `nix build .#hydraJobs.buildRs.x86_64-linux --no-link`
- isolated `cargo check --all-targets` for the publisher-confirm commit
- real nixpkgs evaluation: `systemd` is relevant on Linux and irrelevant on Darwin; `thunderbird-mcp` is relevant on Linux and aarch64-darwin but irrelevant on x86_64-darwin
- historical NixOS/nixpkgs#345939 reproduction: `brainflow` and `python3Packages.brainflow` fail to instantiate on x86_64-darwin because of the Linux-only `bluez` dependency, and the classifier returns `false`

## Deployment

Deploy `github-comment-poster` before `mass-rebuilder` because the evaluator emits a new durable build-plan message. The existing deployment model assumes a single poster consumer for the ordered `build-results` queue.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)
